### PR TITLE
es6-shim: upgrade to v0.35.1

### DIFF
--- a/es6-shim.js
+++ b/es6-shim.js
@@ -1,1966 +1,3777 @@
-// ES6-shim 0.18.0 (c) 2013-2014 Paul Miller (http://paulmillr.com)
-// ES6-shim may be freely distributed under the MIT license.
-// For more details and documentation:
-// https://github.com/paulmillr/es6-shim/
+ /*!
+  * https://github.com/paulmillr/es6-shim
+  * @license es6-shim Copyright 2013-2016 by Paul Miller (http://paulmillr.com)
+  *   and contributors,  MIT License
+  * es6-shim: v0.35.1
+  * see https://github.com/paulmillr/es6-shim/blob/0.35.1/LICENSE
+  * Details and documentation:
+  * https://github.com/paulmillr/es6-shim/
+  */
 
-(function (undefined) {
+// UMD (Universal Module Definition)
+// see https://github.com/umdjs/umd/blob/master/returnExports.js
+(function (root, factory) {
+  /*global define, module, exports */
+  if (typeof define === 'function' && define.amd) {
+    // AMD. Register as an anonymous module.
+    define(factory);
+  } else if (typeof exports === 'object') {
+    // Node. Does not work with strict CommonJS, but
+    // only CommonJS-like environments that support module.exports,
+    // like Node.
+    module.exports = factory();
+  } else {
+    // Browser globals (root is window)
+    root.returnExports = factory();
+  }
+}(this, function () {
   'use strict';
 
-  var isCallableWithoutNew = function (func) {
-    try { func(); }
-    catch (e) { return false; }
-    return true;
-  };
+  var _apply = Function.call.bind(Function.apply);
+  var _call = Function.call.bind(Function.call);
+  var isArray = Array.isArray;
+  var keys = Object.keys;
 
-  var supportsSubclassing = function (C, f) {
-    /* jshint proto:true */
+  var not = function notThunker(func) {
+    return function notThunk() {
+      return !_apply(func, this, arguments);
+    };
+  };
+  var throwsError = function (func) {
     try {
-      var Sub = function () { C.apply(this, arguments); };
-      if (!Sub.__proto__) { return false; /* skip test on IE < 11 */ }
-      Object.setPrototypeOf(Sub, C);
-      Sub.prototype = Object.create(C.prototype, {
-        constructor: { value: C }
-      });
-      return f(Sub);
+      func();
+      return false;
+    } catch (e) {
+      return true;
+    }
+  };
+  var valueOrFalseIfThrows = function valueOrFalseIfThrows(func) {
+    try {
+      return func();
     } catch (e) {
       return false;
     }
   };
 
+  var isCallableWithoutNew = not(throwsError);
   var arePropertyDescriptorsSupported = function () {
-    try {
-      Object.defineProperty({}, 'x', {});
-      return true;
-    } catch (e) { /* this is IE 8. */
-      return false;
-    }
+    // if Object.defineProperty exists but throws, it's IE 8
+    return !throwsError(function () {
+      Object.defineProperty({}, 'x', { get: function () {} });
+    });
   };
+  var supportsDescriptors = !!Object.defineProperty && arePropertyDescriptorsSupported();
+  var functionsHaveNames = (function foo() {}).name === 'foo'; // eslint-disable-line no-extra-parens
 
-  var startsWithRejectsRegex = function () {
-    var rejectsRegex = false;
-    if (String.prototype.startsWith) {
-      try {
-        '/a/'.startsWith(/a/);
-      } catch (e) { /* this is spec compliant */
-        rejectsRegex = true;
-      }
-    }
-    return rejectsRegex;
-  };
+  var _forEach = Function.call.bind(Array.prototype.forEach);
+  var _reduce = Function.call.bind(Array.prototype.reduce);
+  var _filter = Function.call.bind(Array.prototype.filter);
+  var _some = Function.call.bind(Array.prototype.some);
 
-  /*jshint evil: true */
-  var getGlobal = new Function('return this;');
-  /*jshint evil: false */
-
-  var main = function () {
-    var globals = getGlobal();
-    var global_isFinite = globals.isFinite;
-    var supportsDescriptors = !!Object.defineProperty && arePropertyDescriptorsSupported();
-    var startsWithIsCompliant = startsWithRejectsRegex();
-    var _slice = Array.prototype.slice;
-    var _indexOf = String.prototype.indexOf;
-    var _toString = Object.prototype.toString;
-    var _hasOwnProperty = Object.prototype.hasOwnProperty;
-    var ArrayIterator; // make our implementation private
-
-    var defineProperty = function (object, name, value, force) {
-      if (!force && name in object) return;
-      if (supportsDescriptors) {
-        Object.defineProperty(object, name, {
-          configurable: true,
-          enumerable: false,
-          writable: true,
-          value: value
-        });
-      } else {
-        object[name] = value;
-      }
-    };
-
-    // Define configurable, writable and non-enumerable props
-    // if they don’t exist.
-    var defineProperties = function (object, map) {
-      Object.keys(map).forEach(function (name) {
-        var method = map[name];
-        defineProperty(object, name, method, false);
+  var defineProperty = function (object, name, value, force) {
+    if (!force && name in object) { return; }
+    if (supportsDescriptors) {
+      Object.defineProperty(object, name, {
+        configurable: true,
+        enumerable: false,
+        writable: true,
+        value: value
       });
-    };
-
-    // Simple shim for Object.create on ES3 browsers
-    // (unlike real shim, no attempt to support `prototype === null`)
-    var create = Object.create || function (prototype, properties) {
-      function Type() {}
-      Type.prototype = prototype;
-      var object = new Type();
-      if (typeof properties !== "undefined") {
-        defineProperties(object, properties);
-      }
-      return object;
-    };
-
-    // This is a private name in the es6 spec, equal to '[Symbol.iterator]'
-    // we're going to use an arbitrary _-prefixed name to make our shims
-    // work properly with each other, even though we don't have full Iterator
-    // support.  That is, `Array.from(map.keys())` will work, but we don't
-    // pretend to export a "real" Iterator interface.
-    var $iterator$ = (typeof Symbol === 'function' && Symbol.iterator) ||
-      '_es6shim_iterator_';
-    // Firefox ships a partial implementation using the name @@iterator.
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=907077#c14
-    // So use that name if we detect it.
-    if (globals.Set && typeof new globals.Set()['@@iterator'] === 'function') {
-      $iterator$ = '@@iterator';
+    } else {
+      object[name] = value;
     }
-    var addIterator = function (prototype, impl) {
-      if (!impl) { impl = function iterator() { return this; }; }
-      var o = {};
-      o[$iterator$] = impl;
-      defineProperties(prototype, o);
-      /* jshint notypeof: true */
-      if (!prototype[$iterator$] && typeof $iterator$ === 'symbol') {
-        // implementations are buggy when $iterator$ is a Symbol
-        prototype[$iterator$] = impl;
+  };
+
+  // Define configurable, writable and non-enumerable props
+  // if they don’t exist.
+  var defineProperties = function (object, map, forceOverride) {
+    _forEach(keys(map), function (name) {
+      var method = map[name];
+      defineProperty(object, name, method, !!forceOverride);
+    });
+  };
+
+  var _toString = Function.call.bind(Object.prototype.toString);
+  var isCallable = typeof /abc/ === 'function' ? function IsCallableSlow(x) {
+    // Some old browsers (IE, FF) say that typeof /abc/ === 'function'
+    return typeof x === 'function' && _toString(x) === '[object Function]';
+  } : function IsCallableFast(x) { return typeof x === 'function'; };
+
+  var Value = {
+    getter: function (object, name, getter) {
+      if (!supportsDescriptors) {
+        throw new TypeError('getters require true ES5 support');
       }
+      Object.defineProperty(object, name, {
+        configurable: true,
+        enumerable: false,
+        get: getter
+      });
+    },
+    proxy: function (originalObject, key, targetObject) {
+      if (!supportsDescriptors) {
+        throw new TypeError('getters require true ES5 support');
+      }
+      var originalDescriptor = Object.getOwnPropertyDescriptor(originalObject, key);
+      Object.defineProperty(targetObject, key, {
+        configurable: originalDescriptor.configurable,
+        enumerable: originalDescriptor.enumerable,
+        get: function getKey() { return originalObject[key]; },
+        set: function setKey(value) { originalObject[key] = value; }
+      });
+    },
+    redefine: function (object, property, newValue) {
+      if (supportsDescriptors) {
+        var descriptor = Object.getOwnPropertyDescriptor(object, property);
+        descriptor.value = newValue;
+        Object.defineProperty(object, property, descriptor);
+      } else {
+        object[property] = newValue;
+      }
+    },
+    defineByDescriptor: function (object, property, descriptor) {
+      if (supportsDescriptors) {
+        Object.defineProperty(object, property, descriptor);
+      } else if ('value' in descriptor) {
+        object[property] = descriptor.value;
+      }
+    },
+    preserveToString: function (target, source) {
+      if (source && isCallable(source.toString)) {
+        defineProperty(target, 'toString', source.toString.bind(source), true);
+      }
+    }
+  };
+
+  // Simple shim for Object.create on ES3 browsers
+  // (unlike real shim, no attempt to support `prototype === null`)
+  var create = Object.create || function (prototype, properties) {
+    var Prototype = function Prototype() {};
+    Prototype.prototype = prototype;
+    var object = new Prototype();
+    if (typeof properties !== 'undefined') {
+      keys(properties).forEach(function (key) {
+        Value.defineByDescriptor(object, key, properties[key]);
+      });
+    }
+    return object;
+  };
+
+  var supportsSubclassing = function (C, f) {
+    if (!Object.setPrototypeOf) { return false; /* skip test on IE < 11 */ }
+    return valueOrFalseIfThrows(function () {
+      var Sub = function Subclass(arg) {
+        var o = new C(arg);
+        Object.setPrototypeOf(o, Subclass.prototype);
+        return o;
+      };
+      Object.setPrototypeOf(Sub, C);
+      Sub.prototype = create(C.prototype, {
+        constructor: { value: Sub }
+      });
+      return f(Sub);
+    });
+  };
+
+  var getGlobal = function () {
+    /* global self, window, global */
+    // the only reliable means to get the global object is
+    // `Function('return this')()`
+    // However, this causes CSP violations in Chrome apps.
+    if (typeof self !== 'undefined') { return self; }
+    if (typeof window !== 'undefined') { return window; }
+    if (typeof global !== 'undefined') { return global; }
+    throw new Error('unable to locate global object');
+  };
+
+  var globals = getGlobal();
+  var globalIsFinite = globals.isFinite;
+  var _indexOf = Function.call.bind(String.prototype.indexOf);
+  var _arrayIndexOfApply = Function.apply.bind(Array.prototype.indexOf);
+  var _concat = Function.call.bind(Array.prototype.concat);
+  // var _sort = Function.call.bind(Array.prototype.sort);
+  var _strSlice = Function.call.bind(String.prototype.slice);
+  var _push = Function.call.bind(Array.prototype.push);
+  var _pushApply = Function.apply.bind(Array.prototype.push);
+  var _shift = Function.call.bind(Array.prototype.shift);
+  var _max = Math.max;
+  var _min = Math.min;
+  var _floor = Math.floor;
+  var _abs = Math.abs;
+  var _exp = Math.exp;
+  var _log = Math.log;
+  var _sqrt = Math.sqrt;
+  var _hasOwnProperty = Function.call.bind(Object.prototype.hasOwnProperty);
+  var ArrayIterator; // make our implementation private
+  var noop = function () {};
+
+  var Symbol = globals.Symbol || {};
+  var symbolSpecies = Symbol.species || '@@species';
+
+  var numberIsNaN = Number.isNaN || function isNaN(value) {
+    // NaN !== NaN, but they are identical.
+    // NaNs are the only non-reflexive value, i.e., if x !== x,
+    // then x is NaN.
+    // isNaN is broken: it converts its argument to number, so
+    // isNaN('foo') => true
+    return value !== value;
+  };
+  var numberIsFinite = Number.isFinite || function isFinite(value) {
+    return typeof value === 'number' && globalIsFinite(value);
+  };
+  var _sign = isCallable(Math.sign) ? Math.sign : function sign(value) {
+    var number = Number(value);
+    if (number === 0) { return number; }
+    if (numberIsNaN(number)) { return number; }
+    return number < 0 ? -1 : 1;
+  };
+
+  // taken directly from https://github.com/ljharb/is-arguments/blob/master/index.js
+  // can be replaced with require('is-arguments') if we ever use a build process instead
+  var isStandardArguments = function isArguments(value) {
+    return _toString(value) === '[object Arguments]';
+  };
+  var isLegacyArguments = function isArguments(value) {
+    return value !== null &&
+      typeof value === 'object' &&
+      typeof value.length === 'number' &&
+      value.length >= 0 &&
+      _toString(value) !== '[object Array]' &&
+      _toString(value.callee) === '[object Function]';
+  };
+  var isArguments = isStandardArguments(arguments) ? isStandardArguments : isLegacyArguments;
+
+  var Type = {
+    primitive: function (x) { return x === null || (typeof x !== 'function' && typeof x !== 'object'); },
+    string: function (x) { return _toString(x) === '[object String]'; },
+    regex: function (x) { return _toString(x) === '[object RegExp]'; },
+    symbol: function (x) {
+      return typeof globals.Symbol === 'function' && typeof x === 'symbol';
+    }
+  };
+
+  var overrideNative = function overrideNative(object, property, replacement) {
+    var original = object[property];
+    defineProperty(object, property, replacement, true);
+    Value.preserveToString(object[property], original);
+  };
+
+  var hasSymbols = typeof Symbol === 'function' && typeof Symbol['for'] === 'function' && Type.symbol(Symbol());
+
+  // This is a private name in the es6 spec, equal to '[Symbol.iterator]'
+  // we're going to use an arbitrary _-prefixed name to make our shims
+  // work properly with each other, even though we don't have full Iterator
+  // support.  That is, `Array.from(map.keys())` will work, but we don't
+  // pretend to export a "real" Iterator interface.
+  var $iterator$ = Type.symbol(Symbol.iterator) ? Symbol.iterator : '_es6-shim iterator_';
+  // Firefox ships a partial implementation using the name @@iterator.
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=907077#c14
+  // So use that name if we detect it.
+  if (globals.Set && typeof new globals.Set()['@@iterator'] === 'function') {
+    $iterator$ = '@@iterator';
+  }
+
+  // Reflect
+  if (!globals.Reflect) {
+    defineProperty(globals, 'Reflect', {}, true);
+  }
+  var Reflect = globals.Reflect;
+
+  var $String = String;
+
+  var ES = {
+    // http://www.ecma-international.org/ecma-262/6.0/#sec-call
+    Call: function Call(F, V) {
+      var args = arguments.length > 2 ? arguments[2] : [];
+      if (!ES.IsCallable(F)) {
+        throw new TypeError(F + ' is not a function');
+      }
+      return _apply(F, V, args);
+    },
+
+    RequireObjectCoercible: function (x, optMessage) {
+      /* jshint eqnull:true */
+      if (x == null) {
+        throw new TypeError(optMessage || 'Cannot call method on ' + x);
+      }
+      return x;
+    },
+
+    // This might miss the "(non-standard exotic and does not implement
+    // [[Call]])" case from
+    // http://www.ecma-international.org/ecma-262/6.0/#sec-typeof-operator-runtime-semantics-evaluation
+    // but we can't find any evidence these objects exist in practice.
+    // If we find some in the future, you could test `Object(x) === x`,
+    // which is reliable according to
+    // http://www.ecma-international.org/ecma-262/6.0/#sec-toobject
+    // but is not well optimized by runtimes and creates an object
+    // whenever it returns false, and thus is very slow.
+    TypeIsObject: function (x) {
+      if (x === void 0 || x === null || x === true || x === false) {
+        return false;
+      }
+      return typeof x === 'function' || typeof x === 'object';
+    },
+
+    ToObject: function (o, optMessage) {
+      return Object(ES.RequireObjectCoercible(o, optMessage));
+    },
+
+    IsCallable: isCallable,
+
+    IsConstructor: function (x) {
+      // We can't tell callables from constructors in ES5
+      return ES.IsCallable(x);
+    },
+
+    ToInt32: function (x) {
+      return ES.ToNumber(x) >> 0;
+    },
+
+    ToUint32: function (x) {
+      return ES.ToNumber(x) >>> 0;
+    },
+
+    ToNumber: function (value) {
+      if (_toString(value) === '[object Symbol]') {
+        throw new TypeError('Cannot convert a Symbol value to a number');
+      }
+      return +value;
+    },
+
+    ToInteger: function (value) {
+      var number = ES.ToNumber(value);
+      if (numberIsNaN(number)) { return 0; }
+      if (number === 0 || !numberIsFinite(number)) { return number; }
+      return (number > 0 ? 1 : -1) * _floor(_abs(number));
+    },
+
+    ToLength: function (value) {
+      var len = ES.ToInteger(value);
+      if (len <= 0) { return 0; } // includes converting -0 to +0
+      if (len > Number.MAX_SAFE_INTEGER) { return Number.MAX_SAFE_INTEGER; }
+      return len;
+    },
+
+    SameValue: function (a, b) {
+      if (a === b) {
+        // 0 === -0, but they are not identical.
+        if (a === 0) { return 1 / a === 1 / b; }
+        return true;
+      }
+      return numberIsNaN(a) && numberIsNaN(b);
+    },
+
+    SameValueZero: function (a, b) {
+      // same as SameValue except for SameValueZero(+0, -0) == true
+      return (a === b) || (numberIsNaN(a) && numberIsNaN(b));
+    },
+
+    IsIterable: function (o) {
+      return ES.TypeIsObject(o) && (typeof o[$iterator$] !== 'undefined' || isArguments(o));
+    },
+
+    GetIterator: function (o) {
+      if (isArguments(o)) {
+        // special case support for `arguments`
+        return new ArrayIterator(o, 'value');
+      }
+      var itFn = ES.GetMethod(o, $iterator$);
+      if (!ES.IsCallable(itFn)) {
+        // Better diagnostics if itFn is null or undefined
+        throw new TypeError('value is not an iterable');
+      }
+      var it = ES.Call(itFn, o);
+      if (!ES.TypeIsObject(it)) {
+        throw new TypeError('bad iterator');
+      }
+      return it;
+    },
+
+    GetMethod: function (o, p) {
+      var func = ES.ToObject(o)[p];
+      if (func === void 0 || func === null) {
+        return void 0;
+      }
+      if (!ES.IsCallable(func)) {
+        throw new TypeError('Method not callable: ' + p);
+      }
+      return func;
+    },
+
+    IteratorComplete: function (iterResult) {
+      return !!iterResult.done;
+    },
+
+    IteratorClose: function (iterator, completionIsThrow) {
+      var returnMethod = ES.GetMethod(iterator, 'return');
+      if (returnMethod === void 0) {
+        return;
+      }
+      var innerResult, innerException;
+      try {
+        innerResult = ES.Call(returnMethod, iterator);
+      } catch (e) {
+        innerException = e;
+      }
+      if (completionIsThrow) {
+        return;
+      }
+      if (innerException) {
+        throw innerException;
+      }
+      if (!ES.TypeIsObject(innerResult)) {
+        throw new TypeError("Iterator's return method returned a non-object.");
+      }
+    },
+
+    IteratorNext: function (it) {
+      var result = arguments.length > 1 ? it.next(arguments[1]) : it.next();
+      if (!ES.TypeIsObject(result)) {
+        throw new TypeError('bad iterator');
+      }
+      return result;
+    },
+
+    IteratorStep: function (it) {
+      var result = ES.IteratorNext(it);
+      var done = ES.IteratorComplete(result);
+      return done ? false : result;
+    },
+
+    Construct: function (C, args, newTarget, isES6internal) {
+      var target = typeof newTarget === 'undefined' ? C : newTarget;
+
+      if (!isES6internal && Reflect.construct) {
+        // Try to use Reflect.construct if available
+        return Reflect.construct(C, args, target);
+      }
+      // OK, we have to fake it.  This will only work if the
+      // C.[[ConstructorKind]] == "base" -- but that's the only
+      // kind we can make in ES5 code anyway.
+
+      // OrdinaryCreateFromConstructor(target, "%ObjectPrototype%")
+      var proto = target.prototype;
+      if (!ES.TypeIsObject(proto)) {
+        proto = Object.prototype;
+      }
+      var obj = create(proto);
+      // Call the constructor.
+      var result = ES.Call(C, obj, args);
+      return ES.TypeIsObject(result) ? result : obj;
+    },
+
+    SpeciesConstructor: function (O, defaultConstructor) {
+      var C = O.constructor;
+      if (C === void 0) {
+        return defaultConstructor;
+      }
+      if (!ES.TypeIsObject(C)) {
+        throw new TypeError('Bad constructor');
+      }
+      var S = C[symbolSpecies];
+      if (S === void 0 || S === null) {
+        return defaultConstructor;
+      }
+      if (!ES.IsConstructor(S)) {
+        throw new TypeError('Bad @@species');
+      }
+      return S;
+    },
+
+    CreateHTML: function (string, tag, attribute, value) {
+      var S = ES.ToString(string);
+      var p1 = '<' + tag;
+      if (attribute !== '') {
+        var V = ES.ToString(value);
+        var escapedV = V.replace(/"/g, '&quot;');
+        p1 += ' ' + attribute + '="' + escapedV + '"';
+      }
+      var p2 = p1 + '>';
+      var p3 = p2 + S;
+      return p3 + '</' + tag + '>';
+    },
+
+    IsRegExp: function IsRegExp(argument) {
+      if (!ES.TypeIsObject(argument)) {
+        return false;
+      }
+      var isRegExp = argument[Symbol.match];
+      if (typeof isRegExp !== 'undefined') {
+        return !!isRegExp;
+      }
+      return Type.regex(argument);
+    },
+
+    ToString: function ToString(string) {
+      return $String(string);
+    }
+  };
+
+  // Well-known Symbol shims
+  if (supportsDescriptors && hasSymbols) {
+    var defineWellKnownSymbol = function defineWellKnownSymbol(name) {
+      if (Type.symbol(Symbol[name])) {
+        return Symbol[name];
+      }
+      var sym = Symbol['for']('Symbol.' + name);
+      Object.defineProperty(Symbol, name, {
+        configurable: false,
+        enumerable: false,
+        writable: false,
+        value: sym
+      });
+      return sym;
+    };
+    if (!Type.symbol(Symbol.search)) {
+      var symbolSearch = defineWellKnownSymbol('search');
+      var originalSearch = String.prototype.search;
+      defineProperty(RegExp.prototype, symbolSearch, function search(string) {
+        return ES.Call(originalSearch, string, [this]);
+      });
+      var searchShim = function search(regexp) {
+        var O = ES.RequireObjectCoercible(this);
+        if (regexp !== null && typeof regexp !== 'undefined') {
+          var searcher = ES.GetMethod(regexp, symbolSearch);
+          if (typeof searcher !== 'undefined') {
+            return ES.Call(searcher, regexp, [O]);
+          }
+        }
+        return ES.Call(originalSearch, O, [ES.ToString(regexp)]);
+      };
+      overrideNative(String.prototype, 'search', searchShim);
+    }
+    if (!Type.symbol(Symbol.replace)) {
+      var symbolReplace = defineWellKnownSymbol('replace');
+      var originalReplace = String.prototype.replace;
+      defineProperty(RegExp.prototype, symbolReplace, function replace(string, replaceValue) {
+        return ES.Call(originalReplace, string, [this, replaceValue]);
+      });
+      var replaceShim = function replace(searchValue, replaceValue) {
+        var O = ES.RequireObjectCoercible(this);
+        if (searchValue !== null && typeof searchValue !== 'undefined') {
+          var replacer = ES.GetMethod(searchValue, symbolReplace);
+          if (typeof replacer !== 'undefined') {
+            return ES.Call(replacer, searchValue, [O, replaceValue]);
+          }
+        }
+        return ES.Call(originalReplace, O, [ES.ToString(searchValue), replaceValue]);
+      };
+      overrideNative(String.prototype, 'replace', replaceShim);
+    }
+    if (!Type.symbol(Symbol.split)) {
+      var symbolSplit = defineWellKnownSymbol('split');
+      var originalSplit = String.prototype.split;
+      defineProperty(RegExp.prototype, symbolSplit, function split(string, limit) {
+        return ES.Call(originalSplit, string, [this, limit]);
+      });
+      var splitShim = function split(separator, limit) {
+        var O = ES.RequireObjectCoercible(this);
+        if (separator !== null && typeof separator !== 'undefined') {
+          var splitter = ES.GetMethod(separator, symbolSplit);
+          if (typeof splitter !== 'undefined') {
+            return ES.Call(splitter, separator, [O, limit]);
+          }
+        }
+        return ES.Call(originalSplit, O, [ES.ToString(separator), limit]);
+      };
+      overrideNative(String.prototype, 'split', splitShim);
+    }
+    var symbolMatchExists = Type.symbol(Symbol.match);
+    var stringMatchIgnoresSymbolMatch = symbolMatchExists && (function () {
+      // Firefox 41, through Nightly 45 has Symbol.match, but String#match ignores it.
+      // Firefox 40 and below have Symbol.match but String#match works fine.
+      var o = {};
+      o[Symbol.match] = function () { return 42; };
+      return 'a'.match(o) !== 42;
+    }());
+    if (!symbolMatchExists || stringMatchIgnoresSymbolMatch) {
+      var symbolMatch = defineWellKnownSymbol('match');
+
+      var originalMatch = String.prototype.match;
+      defineProperty(RegExp.prototype, symbolMatch, function match(string) {
+        return ES.Call(originalMatch, string, [this]);
+      });
+
+      var matchShim = function match(regexp) {
+        var O = ES.RequireObjectCoercible(this);
+        if (regexp !== null && typeof regexp !== 'undefined') {
+          var matcher = ES.GetMethod(regexp, symbolMatch);
+          if (typeof matcher !== 'undefined') {
+            return ES.Call(matcher, regexp, [O]);
+          }
+        }
+        return ES.Call(originalMatch, O, [ES.ToString(regexp)]);
+      };
+      overrideNative(String.prototype, 'match', matchShim);
+    }
+  }
+
+  var wrapConstructor = function wrapConstructor(original, replacement, keysToSkip) {
+    Value.preserveToString(replacement, original);
+    if (Object.setPrototypeOf) {
+      // sets up proper prototype chain where possible
+      Object.setPrototypeOf(original, replacement);
+    }
+    if (supportsDescriptors) {
+      _forEach(Object.getOwnPropertyNames(original), function (key) {
+        if (key in noop || keysToSkip[key]) { return; }
+        Value.proxy(original, key, replacement);
+      });
+    } else {
+      _forEach(Object.keys(original), function (key) {
+        if (key in noop || keysToSkip[key]) { return; }
+        replacement[key] = original[key];
+      });
+    }
+    replacement.prototype = original.prototype;
+    Value.redefine(original.prototype, 'constructor', replacement);
+  };
+
+  var defaultSpeciesGetter = function () { return this; };
+  var addDefaultSpecies = function (C) {
+    if (supportsDescriptors && !_hasOwnProperty(C, symbolSpecies)) {
+      Value.getter(C, symbolSpecies, defaultSpeciesGetter);
+    }
+  };
+
+  var addIterator = function (prototype, impl) {
+    var implementation = impl || function iterator() { return this; };
+    defineProperty(prototype, $iterator$, implementation);
+    if (!prototype[$iterator$] && Type.symbol($iterator$)) {
+      // implementations are buggy when $iterator$ is a Symbol
+      prototype[$iterator$] = implementation;
+    }
+  };
+
+  var createDataProperty = function createDataProperty(object, name, value) {
+    if (supportsDescriptors) {
+      Object.defineProperty(object, name, {
+        configurable: true,
+        enumerable: true,
+        writable: true,
+        value: value
+      });
+    } else {
+      object[name] = value;
+    }
+  };
+  var createDataPropertyOrThrow = function createDataPropertyOrThrow(object, name, value) {
+    createDataProperty(object, name, value);
+    if (!ES.SameValue(object[name], value)) {
+      throw new TypeError('property is nonconfigurable');
+    }
+  };
+
+  var emulateES6construct = function (o, defaultNewTarget, defaultProto, slots) {
+    // This is an es5 approximation to es6 construct semantics.  in es6,
+    // 'new Foo' invokes Foo.[[Construct]] which (for almost all objects)
+    // just sets the internal variable NewTarget (in es6 syntax `new.target`)
+    // to Foo and then returns Foo().
+
+    // Many ES6 object then have constructors of the form:
+    // 1. If NewTarget is undefined, throw a TypeError exception
+    // 2. Let xxx by OrdinaryCreateFromConstructor(NewTarget, yyy, zzz)
+
+    // So we're going to emulate those first two steps.
+    if (!ES.TypeIsObject(o)) {
+      throw new TypeError('Constructor requires `new`: ' + defaultNewTarget.name);
+    }
+    var proto = defaultNewTarget.prototype;
+    if (!ES.TypeIsObject(proto)) {
+      proto = defaultProto;
+    }
+    var obj = create(proto);
+    for (var name in slots) {
+      if (_hasOwnProperty(slots, name)) {
+        var value = slots[name];
+        defineProperty(obj, name, value, true);
+      }
+    }
+    return obj;
+  };
+
+  // Firefox 31 reports this function's length as 0
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1062484
+  if (String.fromCodePoint && String.fromCodePoint.length !== 1) {
+    var originalFromCodePoint = String.fromCodePoint;
+    overrideNative(String, 'fromCodePoint', function fromCodePoint(codePoints) {
+      return ES.Call(originalFromCodePoint, this, arguments);
+    });
+  }
+
+  var StringShims = {
+    fromCodePoint: function fromCodePoint(codePoints) {
+      var result = [];
+      var next;
+      for (var i = 0, length = arguments.length; i < length; i++) {
+        next = Number(arguments[i]);
+        if (!ES.SameValue(next, ES.ToInteger(next)) || next < 0 || next > 0x10FFFF) {
+          throw new RangeError('Invalid code point ' + next);
+        }
+
+        if (next < 0x10000) {
+          _push(result, String.fromCharCode(next));
+        } else {
+          next -= 0x10000;
+          _push(result, String.fromCharCode((next >> 10) + 0xD800));
+          _push(result, String.fromCharCode((next % 0x400) + 0xDC00));
+        }
+      }
+      return result.join('');
+    },
+
+    raw: function raw(callSite) {
+      var cooked = ES.ToObject(callSite, 'bad callSite');
+      var rawString = ES.ToObject(cooked.raw, 'bad raw value');
+      var len = rawString.length;
+      var literalsegments = ES.ToLength(len);
+      if (literalsegments <= 0) {
+        return '';
+      }
+
+      var stringElements = [];
+      var nextIndex = 0;
+      var nextKey, next, nextSeg, nextSub;
+      while (nextIndex < literalsegments) {
+        nextKey = ES.ToString(nextIndex);
+        nextSeg = ES.ToString(rawString[nextKey]);
+        _push(stringElements, nextSeg);
+        if (nextIndex + 1 >= literalsegments) {
+          break;
+        }
+        next = nextIndex + 1 < arguments.length ? arguments[nextIndex + 1] : '';
+        nextSub = ES.ToString(next);
+        _push(stringElements, nextSub);
+        nextIndex += 1;
+      }
+      return stringElements.join('');
+    }
+  };
+  if (String.raw && String.raw({ raw: { 0: 'x', 1: 'y', length: 2 } }) !== 'xy') {
+    // IE 11 TP has a broken String.raw implementation
+    overrideNative(String, 'raw', StringShims.raw);
+  }
+  defineProperties(String, StringShims);
+
+  // Fast repeat, uses the `Exponentiation by squaring` algorithm.
+  // Perf: http://jsperf.com/string-repeat2/2
+  var stringRepeat = function repeat(s, times) {
+    if (times < 1) { return ''; }
+    if (times % 2) { return repeat(s, times - 1) + s; }
+    var half = repeat(s, times / 2);
+    return half + half;
+  };
+  var stringMaxLength = Infinity;
+
+  var StringPrototypeShims = {
+    repeat: function repeat(times) {
+      var thisStr = ES.ToString(ES.RequireObjectCoercible(this));
+      var numTimes = ES.ToInteger(times);
+      if (numTimes < 0 || numTimes >= stringMaxLength) {
+        throw new RangeError('repeat count must be less than infinity and not overflow maximum string size');
+      }
+      return stringRepeat(thisStr, numTimes);
+    },
+
+    startsWith: function startsWith(searchString) {
+      var S = ES.ToString(ES.RequireObjectCoercible(this));
+      if (ES.IsRegExp(searchString)) {
+        throw new TypeError('Cannot call method "startsWith" with a regex');
+      }
+      var searchStr = ES.ToString(searchString);
+      var position;
+      if (arguments.length > 1) {
+        position = arguments[1];
+      }
+      var start = _max(ES.ToInteger(position), 0);
+      return _strSlice(S, start, start + searchStr.length) === searchStr;
+    },
+
+    endsWith: function endsWith(searchString) {
+      var S = ES.ToString(ES.RequireObjectCoercible(this));
+      if (ES.IsRegExp(searchString)) {
+        throw new TypeError('Cannot call method "endsWith" with a regex');
+      }
+      var searchStr = ES.ToString(searchString);
+      var len = S.length;
+      var endPosition;
+      if (arguments.length > 1) {
+        endPosition = arguments[1];
+      }
+      var pos = typeof endPosition === 'undefined' ? len : ES.ToInteger(endPosition);
+      var end = _min(_max(pos, 0), len);
+      return _strSlice(S, end - searchStr.length, end) === searchStr;
+    },
+
+    includes: function includes(searchString) {
+      if (ES.IsRegExp(searchString)) {
+        throw new TypeError('"includes" does not accept a RegExp');
+      }
+      var searchStr = ES.ToString(searchString);
+      var position;
+      if (arguments.length > 1) {
+        position = arguments[1];
+      }
+      // Somehow this trick makes method 100% compat with the spec.
+      return _indexOf(this, searchStr, position) !== -1;
+    },
+
+    codePointAt: function codePointAt(pos) {
+      var thisStr = ES.ToString(ES.RequireObjectCoercible(this));
+      var position = ES.ToInteger(pos);
+      var length = thisStr.length;
+      if (position >= 0 && position < length) {
+        var first = thisStr.charCodeAt(position);
+        var isEnd = position + 1 === length;
+        if (first < 0xD800 || first > 0xDBFF || isEnd) { return first; }
+        var second = thisStr.charCodeAt(position + 1);
+        if (second < 0xDC00 || second > 0xDFFF) { return first; }
+        return ((first - 0xD800) * 1024) + (second - 0xDC00) + 0x10000;
+      }
+    }
+  };
+  if (String.prototype.includes && 'a'.includes('a', Infinity) !== false) {
+    overrideNative(String.prototype, 'includes', StringPrototypeShims.includes);
+  }
+
+  if (String.prototype.startsWith && String.prototype.endsWith) {
+    var startsWithRejectsRegex = throwsError(function () {
+      /* throws if spec-compliant */
+      '/a/'.startsWith(/a/);
+    });
+    var startsWithHandlesInfinity = valueOrFalseIfThrows(function () {
+      return 'abc'.startsWith('a', Infinity) === false;
+    });
+    if (!startsWithRejectsRegex || !startsWithHandlesInfinity) {
+      // Firefox (< 37?) and IE 11 TP have a noncompliant startsWith implementation
+      overrideNative(String.prototype, 'startsWith', StringPrototypeShims.startsWith);
+      overrideNative(String.prototype, 'endsWith', StringPrototypeShims.endsWith);
+    }
+  }
+  if (hasSymbols) {
+    var startsWithSupportsSymbolMatch = valueOrFalseIfThrows(function () {
+      var re = /a/;
+      re[Symbol.match] = false;
+      return '/a/'.startsWith(re);
+    });
+    if (!startsWithSupportsSymbolMatch) {
+      overrideNative(String.prototype, 'startsWith', StringPrototypeShims.startsWith);
+    }
+    var endsWithSupportsSymbolMatch = valueOrFalseIfThrows(function () {
+      var re = /a/;
+      re[Symbol.match] = false;
+      return '/a/'.endsWith(re);
+    });
+    if (!endsWithSupportsSymbolMatch) {
+      overrideNative(String.prototype, 'endsWith', StringPrototypeShims.endsWith);
+    }
+    var includesSupportsSymbolMatch = valueOrFalseIfThrows(function () {
+      var re = /a/;
+      re[Symbol.match] = false;
+      return '/a/'.includes(re);
+    });
+    if (!includesSupportsSymbolMatch) {
+      overrideNative(String.prototype, 'includes', StringPrototypeShims.includes);
+    }
+  }
+
+  defineProperties(String.prototype, StringPrototypeShims);
+
+  // whitespace from: http://es5.github.io/#x15.5.4.20
+  // implementation from https://github.com/es-shims/es5-shim/blob/v3.4.0/es5-shim.js#L1304-L1324
+  var ws = [
+    '\x09\x0A\x0B\x0C\x0D\x20\xA0\u1680\u180E\u2000\u2001\u2002\u2003',
+    '\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028',
+    '\u2029\uFEFF'
+  ].join('');
+  var trimRegexp = new RegExp('(^[' + ws + ']+)|([' + ws + ']+$)', 'g');
+  var trimShim = function trim() {
+    return ES.ToString(ES.RequireObjectCoercible(this)).replace(trimRegexp, '');
+  };
+  var nonWS = ['\u0085', '\u200b', '\ufffe'].join('');
+  var nonWSregex = new RegExp('[' + nonWS + ']', 'g');
+  var isBadHexRegex = /^[\-+]0x[0-9a-f]+$/i;
+  var hasStringTrimBug = nonWS.trim().length !== nonWS.length;
+  defineProperty(String.prototype, 'trim', trimShim, hasStringTrimBug);
+
+  // Given an argument x, it will return an IteratorResult object,
+  // with value set to x and done to false.
+  // Given no arguments, it will return an iterator completion object.
+  var iteratorResult = function (x) {
+    return { value: x, done: arguments.length === 0 };
+  };
+
+  // see http://www.ecma-international.org/ecma-262/6.0/#sec-string.prototype-@@iterator
+  var StringIterator = function (s) {
+    ES.RequireObjectCoercible(s);
+    this._s = ES.ToString(s);
+    this._i = 0;
+  };
+  StringIterator.prototype.next = function () {
+    var s = this._s;
+    var i = this._i;
+    if (typeof s === 'undefined' || i >= s.length) {
+      this._s = void 0;
+      return iteratorResult();
+    }
+    var first = s.charCodeAt(i);
+    var second, len;
+    if (first < 0xD800 || first > 0xDBFF || (i + 1) === s.length) {
+      len = 1;
+    } else {
+      second = s.charCodeAt(i + 1);
+      len = (second < 0xDC00 || second > 0xDFFF) ? 1 : 2;
+    }
+    this._i = i + len;
+    return iteratorResult(s.substr(i, len));
+  };
+  addIterator(StringIterator.prototype);
+  addIterator(String.prototype, function () {
+    return new StringIterator(this);
+  });
+
+  var ArrayShims = {
+    from: function from(items) {
+      var C = this;
+      var mapFn;
+      if (arguments.length > 1) {
+        mapFn = arguments[1];
+      }
+      var mapping, T;
+      if (typeof mapFn === 'undefined') {
+        mapping = false;
+      } else {
+        if (!ES.IsCallable(mapFn)) {
+          throw new TypeError('Array.from: when provided, the second argument must be a function');
+        }
+        if (arguments.length > 2) {
+          T = arguments[2];
+        }
+        mapping = true;
+      }
+
+      // Note that that Arrays will use ArrayIterator:
+      // https://bugs.ecmascript.org/show_bug.cgi?id=2416
+      var usingIterator = typeof (isArguments(items) || ES.GetMethod(items, $iterator$)) !== 'undefined';
+
+      var length, result, i;
+      if (usingIterator) {
+        result = ES.IsConstructor(C) ? Object(new C()) : [];
+        var iterator = ES.GetIterator(items);
+        var next, nextValue;
+
+        i = 0;
+        while (true) {
+          next = ES.IteratorStep(iterator);
+          if (next === false) {
+            break;
+          }
+          nextValue = next.value;
+          try {
+            if (mapping) {
+              nextValue = typeof T === 'undefined' ? mapFn(nextValue, i) : _call(mapFn, T, nextValue, i);
+            }
+            result[i] = nextValue;
+          } catch (e) {
+            ES.IteratorClose(iterator, true);
+            throw e;
+          }
+          i += 1;
+        }
+        length = i;
+      } else {
+        var arrayLike = ES.ToObject(items);
+        length = ES.ToLength(arrayLike.length);
+        result = ES.IsConstructor(C) ? Object(new C(length)) : new Array(length);
+        var value;
+        for (i = 0; i < length; ++i) {
+          value = arrayLike[i];
+          if (mapping) {
+            value = typeof T === 'undefined' ? mapFn(value, i) : _call(mapFn, T, value, i);
+          }
+          createDataPropertyOrThrow(result, i, value);
+        }
+      }
+
+      result.length = length;
+      return result;
+    },
+
+    of: function of() {
+      var len = arguments.length;
+      var C = this;
+      var A = isArray(C) || !ES.IsCallable(C) ? new Array(len) : ES.Construct(C, [len]);
+      for (var k = 0; k < len; ++k) {
+        createDataPropertyOrThrow(A, k, arguments[k]);
+      }
+      A.length = len;
+      return A;
+    }
+  };
+  defineProperties(Array, ArrayShims);
+  addDefaultSpecies(Array);
+
+  // Our ArrayIterator is private; see
+  // https://github.com/paulmillr/es6-shim/issues/252
+  ArrayIterator = function (array, kind) {
+    this.i = 0;
+    this.array = array;
+    this.kind = kind;
+  };
+
+  defineProperties(ArrayIterator.prototype, {
+    next: function () {
+      var i = this.i;
+      var array = this.array;
+      if (!(this instanceof ArrayIterator)) {
+        throw new TypeError('Not an ArrayIterator');
+      }
+      if (typeof array !== 'undefined') {
+        var len = ES.ToLength(array.length);
+        for (; i < len; i++) {
+          var kind = this.kind;
+          var retval;
+          if (kind === 'key') {
+            retval = i;
+          } else if (kind === 'value') {
+            retval = array[i];
+          } else if (kind === 'entry') {
+            retval = [i, array[i]];
+          }
+          this.i = i + 1;
+          return iteratorResult(retval);
+        }
+      }
+      this.array = void 0;
+      return iteratorResult();
+    }
+  });
+  addIterator(ArrayIterator.prototype);
+
+/*
+  var orderKeys = function orderKeys(a, b) {
+    var aNumeric = String(ES.ToInteger(a)) === a;
+    var bNumeric = String(ES.ToInteger(b)) === b;
+    if (aNumeric && bNumeric) {
+      return b - a;
+    } else if (aNumeric && !bNumeric) {
+      return -1;
+    } else if (!aNumeric && bNumeric) {
+      return 1;
+    } else {
+      return a.localeCompare(b);
+    }
+  };
+
+  var getAllKeys = function getAllKeys(object) {
+    var ownKeys = [];
+    var keys = [];
+
+    for (var key in object) {
+      _push(_hasOwnProperty(object, key) ? ownKeys : keys, key);
+    }
+    _sort(ownKeys, orderKeys);
+    _sort(keys, orderKeys);
+
+    return _concat(ownKeys, keys);
+  };
+  */
+
+  // note: this is positioned here because it depends on ArrayIterator
+  var arrayOfSupportsSubclassing = Array.of === ArrayShims.of || (function () {
+    // Detects a bug in Webkit nightly r181886
+    var Foo = function Foo(len) { this.length = len; };
+    Foo.prototype = [];
+    var fooArr = Array.of.apply(Foo, [1, 2]);
+    return fooArr instanceof Foo && fooArr.length === 2;
+  }());
+  if (!arrayOfSupportsSubclassing) {
+    overrideNative(Array, 'of', ArrayShims.of);
+  }
+
+  var ArrayPrototypeShims = {
+    copyWithin: function copyWithin(target, start) {
+      var o = ES.ToObject(this);
+      var len = ES.ToLength(o.length);
+      var relativeTarget = ES.ToInteger(target);
+      var relativeStart = ES.ToInteger(start);
+      var to = relativeTarget < 0 ? _max(len + relativeTarget, 0) : _min(relativeTarget, len);
+      var from = relativeStart < 0 ? _max(len + relativeStart, 0) : _min(relativeStart, len);
+      var end;
+      if (arguments.length > 2) {
+        end = arguments[2];
+      }
+      var relativeEnd = typeof end === 'undefined' ? len : ES.ToInteger(end);
+      var finalItem = relativeEnd < 0 ? _max(len + relativeEnd, 0) : _min(relativeEnd, len);
+      var count = _min(finalItem - from, len - to);
+      var direction = 1;
+      if (from < to && to < (from + count)) {
+        direction = -1;
+        from += count - 1;
+        to += count - 1;
+      }
+      while (count > 0) {
+        if (from in o) {
+          o[to] = o[from];
+        } else {
+          delete o[to];
+        }
+        from += direction;
+        to += direction;
+        count -= 1;
+      }
+      return o;
+    },
+
+    fill: function fill(value) {
+      var start;
+      if (arguments.length > 1) {
+        start = arguments[1];
+      }
+      var end;
+      if (arguments.length > 2) {
+        end = arguments[2];
+      }
+      var O = ES.ToObject(this);
+      var len = ES.ToLength(O.length);
+      start = ES.ToInteger(typeof start === 'undefined' ? 0 : start);
+      end = ES.ToInteger(typeof end === 'undefined' ? len : end);
+
+      var relativeStart = start < 0 ? _max(len + start, 0) : _min(start, len);
+      var relativeEnd = end < 0 ? len + end : end;
+
+      for (var i = relativeStart; i < len && i < relativeEnd; ++i) {
+        O[i] = value;
+      }
+      return O;
+    },
+
+    find: function find(predicate) {
+      var list = ES.ToObject(this);
+      var length = ES.ToLength(list.length);
+      if (!ES.IsCallable(predicate)) {
+        throw new TypeError('Array#find: predicate must be a function');
+      }
+      var thisArg = arguments.length > 1 ? arguments[1] : null;
+      for (var i = 0, value; i < length; i++) {
+        value = list[i];
+        if (thisArg) {
+          if (_call(predicate, thisArg, value, i, list)) {
+            return value;
+          }
+        } else if (predicate(value, i, list)) {
+          return value;
+        }
+      }
+    },
+
+    findIndex: function findIndex(predicate) {
+      var list = ES.ToObject(this);
+      var length = ES.ToLength(list.length);
+      if (!ES.IsCallable(predicate)) {
+        throw new TypeError('Array#findIndex: predicate must be a function');
+      }
+      var thisArg = arguments.length > 1 ? arguments[1] : null;
+      for (var i = 0; i < length; i++) {
+        if (thisArg) {
+          if (_call(predicate, thisArg, list[i], i, list)) {
+            return i;
+          }
+        } else if (predicate(list[i], i, list)) {
+          return i;
+        }
+      }
+      return -1;
+    },
+
+    keys: function keys() {
+      return new ArrayIterator(this, 'key');
+    },
+
+    values: function values() {
+      return new ArrayIterator(this, 'value');
+    },
+
+    entries: function entries() {
+      return new ArrayIterator(this, 'entry');
+    }
+  };
+  // Safari 7.1 defines Array#keys and Array#entries natively,
+  // but the resulting ArrayIterator objects don't have a "next" method.
+  if (Array.prototype.keys && !ES.IsCallable([1].keys().next)) {
+    delete Array.prototype.keys;
+  }
+  if (Array.prototype.entries && !ES.IsCallable([1].entries().next)) {
+    delete Array.prototype.entries;
+  }
+
+  // Chrome 38 defines Array#keys and Array#entries, and Array#@@iterator, but not Array#values
+  if (Array.prototype.keys && Array.prototype.entries && !Array.prototype.values && Array.prototype[$iterator$]) {
+    defineProperties(Array.prototype, {
+      values: Array.prototype[$iterator$]
+    });
+    if (Type.symbol(Symbol.unscopables)) {
+      Array.prototype[Symbol.unscopables].values = true;
+    }
+  }
+  // Chrome 40 defines Array#values with the incorrect name, although Array#{keys,entries} have the correct name
+  if (functionsHaveNames && Array.prototype.values && Array.prototype.values.name !== 'values') {
+    var originalArrayPrototypeValues = Array.prototype.values;
+    overrideNative(Array.prototype, 'values', function values() { return ES.Call(originalArrayPrototypeValues, this, arguments); });
+    defineProperty(Array.prototype, $iterator$, Array.prototype.values, true);
+  }
+  defineProperties(Array.prototype, ArrayPrototypeShims);
+
+  if (1 / [true].indexOf(true, -0) < 0) {
+    // indexOf when given a position arg of -0 should return +0.
+    // https://github.com/tc39/ecma262/pull/316
+    defineProperty(Array.prototype, 'indexOf', function indexOf(searchElement) {
+      var value = _arrayIndexOfApply(this, arguments);
+      if (value === 0 && (1 / value) < 0) {
+        return 0;
+      }
+      return value;
+    }, true);
+  }
+
+  addIterator(Array.prototype, function () { return this.values(); });
+  // Chrome defines keys/values/entries on Array, but doesn't give us
+  // any way to identify its iterator.  So add our own shimmed field.
+  if (Object.getPrototypeOf) {
+    addIterator(Object.getPrototypeOf([].values()));
+  }
+
+  // note: this is positioned here because it relies on Array#entries
+  var arrayFromSwallowsNegativeLengths = (function () {
+    // Detects a Firefox bug in v32
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1063993
+    return valueOrFalseIfThrows(function () {
+      return Array.from({ length: -1 }).length === 0;
+    });
+  }());
+  var arrayFromHandlesIterables = (function () {
+    // Detects a bug in Webkit nightly r181886
+    var arr = Array.from([0].entries());
+    return arr.length === 1 && isArray(arr[0]) && arr[0][0] === 0 && arr[0][1] === 0;
+  }());
+  if (!arrayFromSwallowsNegativeLengths || !arrayFromHandlesIterables) {
+    overrideNative(Array, 'from', ArrayShims.from);
+  }
+  var arrayFromHandlesUndefinedMapFunction = (function () {
+    // Microsoft Edge v0.11 throws if the mapFn argument is *provided* but undefined,
+    // but the spec doesn't care if it's provided or not - undefined doesn't throw.
+    return valueOrFalseIfThrows(function () {
+      return Array.from([0], void 0);
+    });
+  }());
+  if (!arrayFromHandlesUndefinedMapFunction) {
+    var origArrayFrom = Array.from;
+    overrideNative(Array, 'from', function from(items) {
+      if (arguments.length > 1 && typeof arguments[1] !== 'undefined') {
+        return ES.Call(origArrayFrom, this, arguments);
+      } else {
+        return _call(origArrayFrom, this, items);
+      }
+    });
+  }
+
+  var int32sAsOne = -(Math.pow(2, 32) - 1);
+  var toLengthsCorrectly = function (method, reversed) {
+    var obj = { length: int32sAsOne };
+    obj[reversed ? (obj.length >>> 0) - 1 : 0] = true;
+    return valueOrFalseIfThrows(function () {
+      _call(method, obj, function () {
+        // note: in nonconforming browsers, this will be called
+        // -1 >>> 0 times, which is 4294967295, so the throw matters.
+        throw new RangeError('should not reach here');
+      }, []);
+      return true;
+    });
+  };
+  if (!toLengthsCorrectly(Array.prototype.forEach)) {
+    var originalForEach = Array.prototype.forEach;
+    overrideNative(Array.prototype, 'forEach', function forEach(callbackFn) {
+      return ES.Call(originalForEach, this.length >= 0 ? this : [], arguments);
+    }, true);
+  }
+  if (!toLengthsCorrectly(Array.prototype.map)) {
+    var originalMap = Array.prototype.map;
+    overrideNative(Array.prototype, 'map', function map(callbackFn) {
+      return ES.Call(originalMap, this.length >= 0 ? this : [], arguments);
+    }, true);
+  }
+  if (!toLengthsCorrectly(Array.prototype.filter)) {
+    var originalFilter = Array.prototype.filter;
+    overrideNative(Array.prototype, 'filter', function filter(callbackFn) {
+      return ES.Call(originalFilter, this.length >= 0 ? this : [], arguments);
+    }, true);
+  }
+  if (!toLengthsCorrectly(Array.prototype.some)) {
+    var originalSome = Array.prototype.some;
+    overrideNative(Array.prototype, 'some', function some(callbackFn) {
+      return ES.Call(originalSome, this.length >= 0 ? this : [], arguments);
+    }, true);
+  }
+  if (!toLengthsCorrectly(Array.prototype.every)) {
+    var originalEvery = Array.prototype.every;
+    overrideNative(Array.prototype, 'every', function every(callbackFn) {
+      return ES.Call(originalEvery, this.length >= 0 ? this : [], arguments);
+    }, true);
+  }
+  if (!toLengthsCorrectly(Array.prototype.reduce)) {
+    var originalReduce = Array.prototype.reduce;
+    overrideNative(Array.prototype, 'reduce', function reduce(callbackFn) {
+      return ES.Call(originalReduce, this.length >= 0 ? this : [], arguments);
+    }, true);
+  }
+  if (!toLengthsCorrectly(Array.prototype.reduceRight, true)) {
+    var originalReduceRight = Array.prototype.reduceRight;
+    overrideNative(Array.prototype, 'reduceRight', function reduceRight(callbackFn) {
+      return ES.Call(originalReduceRight, this.length >= 0 ? this : [], arguments);
+    }, true);
+  }
+
+  var lacksOctalSupport = Number('0o10') !== 8;
+  var lacksBinarySupport = Number('0b10') !== 2;
+  var trimsNonWhitespace = _some(nonWS, function (c) {
+    return Number(c + 0 + c) === 0;
+  });
+  if (lacksOctalSupport || lacksBinarySupport || trimsNonWhitespace) {
+    var OrigNumber = Number;
+    var binaryRegex = /^0b[01]+$/i;
+    var octalRegex = /^0o[0-7]+$/i;
+    // Note that in IE 8, RegExp.prototype.test doesn't seem to exist: ie, "test" is an own property of regexes. wtf.
+    var isBinary = binaryRegex.test.bind(binaryRegex);
+    var isOctal = octalRegex.test.bind(octalRegex);
+    var toPrimitive = function (O) { // need to replace this with `es-to-primitive/es6`
+      var result;
+      if (typeof O.valueOf === 'function') {
+        result = O.valueOf();
+        if (Type.primitive(result)) {
+          return result;
+        }
+      }
+      if (typeof O.toString === 'function') {
+        result = O.toString();
+        if (Type.primitive(result)) {
+          return result;
+        }
+      }
+      throw new TypeError('No default value');
+    };
+    var hasNonWS = nonWSregex.test.bind(nonWSregex);
+    var isBadHex = isBadHexRegex.test.bind(isBadHexRegex);
+    var NumberShim = (function () {
+      // this is wrapped in an IIFE because of IE 6-8's wacky scoping issues with named function expressions.
+      var NumberShim = function Number(value) {
+        var primValue;
+        if (arguments.length > 0) {
+          primValue = Type.primitive(value) ? value : toPrimitive(value, 'number');
+        } else {
+          primValue = 0;
+        }
+        if (typeof primValue === 'string') {
+          primValue = ES.Call(trimShim, primValue);
+          if (isBinary(primValue)) {
+            primValue = parseInt(_strSlice(primValue, 2), 2);
+          } else if (isOctal(primValue)) {
+            primValue = parseInt(_strSlice(primValue, 2), 8);
+          } else if (hasNonWS(primValue) || isBadHex(primValue)) {
+            primValue = NaN;
+          }
+        }
+        var receiver = this;
+        var valueOfSucceeds = valueOrFalseIfThrows(function () {
+          OrigNumber.prototype.valueOf.call(receiver);
+          return true;
+        });
+        if (receiver instanceof NumberShim && !valueOfSucceeds) {
+          return new OrigNumber(primValue);
+        }
+        /* jshint newcap: false */
+        return OrigNumber(primValue);
+        /* jshint newcap: true */
+      };
+      return NumberShim;
+    }());
+    wrapConstructor(OrigNumber, NumberShim, {});
+    // this is necessary for ES3 browsers, where these properties are non-enumerable.
+    defineProperties(NumberShim, {
+      NaN: OrigNumber.NaN,
+      MAX_VALUE: OrigNumber.MAX_VALUE,
+      MIN_VALUE: OrigNumber.MIN_VALUE,
+      NEGATIVE_INFINITY: OrigNumber.NEGATIVE_INFINITY,
+      POSITIVE_INFINITY: OrigNumber.POSITIVE_INFINITY
+    });
+    /* globals Number: true */
+    /* eslint-disable no-undef */
+    /* jshint -W020 */
+    Number = NumberShim;
+    Value.redefine(globals, 'Number', NumberShim);
+    /* jshint +W020 */
+    /* eslint-enable no-undef */
+    /* globals Number: false */
+  }
+
+  var maxSafeInteger = Math.pow(2, 53) - 1;
+  defineProperties(Number, {
+    MAX_SAFE_INTEGER: maxSafeInteger,
+    MIN_SAFE_INTEGER: -maxSafeInteger,
+    EPSILON: 2.220446049250313e-16,
+
+    parseInt: globals.parseInt,
+    parseFloat: globals.parseFloat,
+
+    isFinite: numberIsFinite,
+
+    isInteger: function isInteger(value) {
+      return numberIsFinite(value) && ES.ToInteger(value) === value;
+    },
+
+    isSafeInteger: function isSafeInteger(value) {
+      return Number.isInteger(value) && _abs(value) <= Number.MAX_SAFE_INTEGER;
+    },
+
+    isNaN: numberIsNaN
+  });
+  // Firefox 37 has a conforming Number.parseInt, but it's not === to the global parseInt (fixed in v40)
+  defineProperty(Number, 'parseInt', globals.parseInt, Number.parseInt !== globals.parseInt);
+
+  // Work around bugs in Array#find and Array#findIndex -- early
+  // implementations skipped holes in sparse arrays. (Note that the
+  // implementations of find/findIndex indirectly use shimmed
+  // methods of Number, so this test has to happen down here.)
+  /*jshint elision: true */
+  /* eslint-disable no-sparse-arrays */
+  if (![, 1].find(function (item, idx) { return idx === 0; })) {
+    overrideNative(Array.prototype, 'find', ArrayPrototypeShims.find);
+  }
+  if ([, 1].findIndex(function (item, idx) { return idx === 0; }) !== 0) {
+    overrideNative(Array.prototype, 'findIndex', ArrayPrototypeShims.findIndex);
+  }
+  /* eslint-enable no-sparse-arrays */
+  /*jshint elision: false */
+
+  var isEnumerableOn = Function.bind.call(Function.bind, Object.prototype.propertyIsEnumerable);
+  var ensureEnumerable = function ensureEnumerable(obj, prop) {
+    if (supportsDescriptors && isEnumerableOn(obj, prop)) {
+      Object.defineProperty(obj, prop, { enumerable: false });
+    }
+  };
+  var sliceArgs = function sliceArgs() {
+    // per https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments
+    // and https://gist.github.com/WebReflection/4327762cb87a8c634a29
+    var initial = Number(this);
+    var len = arguments.length;
+    var desiredArgCount = len - initial;
+    var args = new Array(desiredArgCount < 0 ? 0 : desiredArgCount);
+    for (var i = initial; i < len; ++i) {
+      args[i - initial] = arguments[i];
+    }
+    return args;
+  };
+  var assignTo = function assignTo(source) {
+    return function assignToSource(target, key) {
+      target[key] = source[key];
+      return target;
+    };
+  };
+  var assignReducer = function (target, source) {
+    var sourceKeys = keys(Object(source));
+    var symbols;
+    if (ES.IsCallable(Object.getOwnPropertySymbols)) {
+      symbols = _filter(Object.getOwnPropertySymbols(Object(source)), isEnumerableOn(source));
+    }
+    return _reduce(_concat(sourceKeys, symbols || []), assignTo(source), target);
+  };
+
+  var ObjectShims = {
+    // 19.1.3.1
+    assign: function (target, source) {
+      var to = ES.ToObject(target, 'Cannot convert undefined or null to object');
+      return _reduce(ES.Call(sliceArgs, 1, arguments), assignReducer, to);
+    },
+
+    // Added in WebKit in https://bugs.webkit.org/show_bug.cgi?id=143865
+    is: function is(a, b) {
+      return ES.SameValue(a, b);
+    }
+  };
+  var assignHasPendingExceptions = Object.assign && Object.preventExtensions && (function () {
+    // Firefox 37 still has "pending exception" logic in its Object.assign implementation,
+    // which is 72% slower than our shim, and Firefox 40's native implementation.
+    var thrower = Object.preventExtensions({ 1: 2 });
+    try {
+      Object.assign(thrower, 'xy');
+    } catch (e) {
+      return thrower[1] === 'y';
+    }
+  }());
+  if (assignHasPendingExceptions) {
+    overrideNative(Object, 'assign', ObjectShims.assign);
+  }
+  defineProperties(Object, ObjectShims);
+
+  if (supportsDescriptors) {
+    var ES5ObjectShims = {
+      // 19.1.3.9
+      // shim from https://gist.github.com/WebReflection/5593554
+      setPrototypeOf: (function (Object, magic) {
+        var set;
+
+        var checkArgs = function (O, proto) {
+          if (!ES.TypeIsObject(O)) {
+            throw new TypeError('cannot set prototype on a non-object');
+          }
+          if (!(proto === null || ES.TypeIsObject(proto))) {
+            throw new TypeError('can only set prototype to an object or null' + proto);
+          }
+        };
+
+        var setPrototypeOf = function (O, proto) {
+          checkArgs(O, proto);
+          _call(set, O, proto);
+          return O;
+        };
+
+        try {
+          // this works already in Firefox and Safari
+          set = Object.getOwnPropertyDescriptor(Object.prototype, magic).set;
+          _call(set, {}, null);
+        } catch (e) {
+          if (Object.prototype !== {}[magic]) {
+            // IE < 11 cannot be shimmed
+            return;
+          }
+          // probably Chrome or some old Mobile stock browser
+          set = function (proto) {
+            this[magic] = proto;
+          };
+          // please note that this will **not** work
+          // in those browsers that do not inherit
+          // __proto__ by mistake from Object.prototype
+          // in these cases we should probably throw an error
+          // or at least be informed about the issue
+          setPrototypeOf.polyfill = setPrototypeOf(
+            setPrototypeOf({}, null),
+            Object.prototype
+          ) instanceof Object;
+          // setPrototypeOf.polyfill === true means it works as meant
+          // setPrototypeOf.polyfill === false means it's not 100% reliable
+          // setPrototypeOf.polyfill === undefined
+          // or
+          // setPrototypeOf.polyfill ==  null means it's not a polyfill
+          // which means it works as expected
+          // we can even delete Object.prototype.__proto__;
+        }
+        return setPrototypeOf;
+      }(Object, '__proto__'))
     };
 
-    // taken directly from https://github.com/ljharb/is-arguments/blob/master/index.js
-    // can be replaced with require('is-arguments') if we ever use a build process instead
-    var isArguments = function isArguments(value) {
-      var str = _toString.call(value);
-      var result = str === '[object Arguments]';
-      if (!result) {
-        result = str !== '[object Array]' &&
-          value !== null &&
-          typeof value === 'object' &&
-          typeof value.length === 'number' &&
-          value.length >= 0 &&
-          _toString.call(value.callee) === '[object Function]';
+    defineProperties(Object, ES5ObjectShims);
+  }
+
+  // Workaround bug in Opera 12 where setPrototypeOf(x, null) doesn't work,
+  // but Object.create(null) does.
+  if (Object.setPrototypeOf && Object.getPrototypeOf &&
+      Object.getPrototypeOf(Object.setPrototypeOf({}, null)) !== null &&
+      Object.getPrototypeOf(Object.create(null)) === null) {
+    (function () {
+      var FAKENULL = Object.create(null);
+      var gpo = Object.getPrototypeOf;
+      var spo = Object.setPrototypeOf;
+      Object.getPrototypeOf = function (o) {
+        var result = gpo(o);
+        return result === FAKENULL ? null : result;
+      };
+      Object.setPrototypeOf = function (o, p) {
+        var proto = p === null ? FAKENULL : p;
+        return spo(o, proto);
+      };
+      Object.setPrototypeOf.polyfill = false;
+    }());
+  }
+
+  var objectKeysAcceptsPrimitives = !throwsError(function () { Object.keys('foo'); });
+  if (!objectKeysAcceptsPrimitives) {
+    var originalObjectKeys = Object.keys;
+    overrideNative(Object, 'keys', function keys(value) {
+      return originalObjectKeys(ES.ToObject(value));
+    });
+    keys = Object.keys;
+  }
+  var objectKeysRejectsRegex = throwsError(function () { Object.keys(/a/g); });
+  if (objectKeysRejectsRegex) {
+    var regexRejectingObjectKeys = Object.keys;
+    overrideNative(Object, 'keys', function keys(value) {
+      if (Type.regex(value)) {
+        var regexKeys = [];
+        for (var k in value) {
+          if (_hasOwnProperty(value, k)) {
+            _push(regexKeys, k);
+          }
+        }
+        return regexKeys;
+      }
+      return regexRejectingObjectKeys(value);
+    });
+    keys = Object.keys;
+  }
+
+  if (Object.getOwnPropertyNames) {
+    var objectGOPNAcceptsPrimitives = !throwsError(function () { Object.getOwnPropertyNames('foo'); });
+    if (!objectGOPNAcceptsPrimitives) {
+      var cachedWindowNames = typeof window === 'object' ? Object.getOwnPropertyNames(window) : [];
+      var originalObjectGetOwnPropertyNames = Object.getOwnPropertyNames;
+      overrideNative(Object, 'getOwnPropertyNames', function getOwnPropertyNames(value) {
+        var val = ES.ToObject(value);
+        if (_toString(val) === '[object Window]') {
+          try {
+            return originalObjectGetOwnPropertyNames(val);
+          } catch (e) {
+            // IE bug where layout engine calls userland gOPN for cross-domain `window` objects
+            return _concat([], cachedWindowNames);
+          }
+        }
+        return originalObjectGetOwnPropertyNames(val);
+      });
+    }
+  }
+  if (Object.getOwnPropertyDescriptor) {
+    var objectGOPDAcceptsPrimitives = !throwsError(function () { Object.getOwnPropertyDescriptor('foo', 'bar'); });
+    if (!objectGOPDAcceptsPrimitives) {
+      var originalObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+      overrideNative(Object, 'getOwnPropertyDescriptor', function getOwnPropertyDescriptor(value, property) {
+        return originalObjectGetOwnPropertyDescriptor(ES.ToObject(value), property);
+      });
+    }
+  }
+  if (Object.seal) {
+    var objectSealAcceptsPrimitives = !throwsError(function () { Object.seal('foo'); });
+    if (!objectSealAcceptsPrimitives) {
+      var originalObjectSeal = Object.seal;
+      overrideNative(Object, 'seal', function seal(value) {
+        if (!ES.TypeIsObject(value)) { return value; }
+        return originalObjectSeal(value);
+      });
+    }
+  }
+  if (Object.isSealed) {
+    var objectIsSealedAcceptsPrimitives = !throwsError(function () { Object.isSealed('foo'); });
+    if (!objectIsSealedAcceptsPrimitives) {
+      var originalObjectIsSealed = Object.isSealed;
+      overrideNative(Object, 'isSealed', function isSealed(value) {
+        if (!ES.TypeIsObject(value)) { return true; }
+        return originalObjectIsSealed(value);
+      });
+    }
+  }
+  if (Object.freeze) {
+    var objectFreezeAcceptsPrimitives = !throwsError(function () { Object.freeze('foo'); });
+    if (!objectFreezeAcceptsPrimitives) {
+      var originalObjectFreeze = Object.freeze;
+      overrideNative(Object, 'freeze', function freeze(value) {
+        if (!ES.TypeIsObject(value)) { return value; }
+        return originalObjectFreeze(value);
+      });
+    }
+  }
+  if (Object.isFrozen) {
+    var objectIsFrozenAcceptsPrimitives = !throwsError(function () { Object.isFrozen('foo'); });
+    if (!objectIsFrozenAcceptsPrimitives) {
+      var originalObjectIsFrozen = Object.isFrozen;
+      overrideNative(Object, 'isFrozen', function isFrozen(value) {
+        if (!ES.TypeIsObject(value)) { return true; }
+        return originalObjectIsFrozen(value);
+      });
+    }
+  }
+  if (Object.preventExtensions) {
+    var objectPreventExtensionsAcceptsPrimitives = !throwsError(function () { Object.preventExtensions('foo'); });
+    if (!objectPreventExtensionsAcceptsPrimitives) {
+      var originalObjectPreventExtensions = Object.preventExtensions;
+      overrideNative(Object, 'preventExtensions', function preventExtensions(value) {
+        if (!ES.TypeIsObject(value)) { return value; }
+        return originalObjectPreventExtensions(value);
+      });
+    }
+  }
+  if (Object.isExtensible) {
+    var objectIsExtensibleAcceptsPrimitives = !throwsError(function () { Object.isExtensible('foo'); });
+    if (!objectIsExtensibleAcceptsPrimitives) {
+      var originalObjectIsExtensible = Object.isExtensible;
+      overrideNative(Object, 'isExtensible', function isExtensible(value) {
+        if (!ES.TypeIsObject(value)) { return false; }
+        return originalObjectIsExtensible(value);
+      });
+    }
+  }
+  if (Object.getPrototypeOf) {
+    var objectGetProtoAcceptsPrimitives = !throwsError(function () { Object.getPrototypeOf('foo'); });
+    if (!objectGetProtoAcceptsPrimitives) {
+      var originalGetProto = Object.getPrototypeOf;
+      overrideNative(Object, 'getPrototypeOf', function getPrototypeOf(value) {
+        return originalGetProto(ES.ToObject(value));
+      });
+    }
+  }
+
+  var hasFlags = supportsDescriptors && (function () {
+    var desc = Object.getOwnPropertyDescriptor(RegExp.prototype, 'flags');
+    return desc && ES.IsCallable(desc.get);
+  }());
+  if (supportsDescriptors && !hasFlags) {
+    var regExpFlagsGetter = function flags() {
+      if (!ES.TypeIsObject(this)) {
+        throw new TypeError('Method called on incompatible type: must be an object.');
+      }
+      var result = '';
+      if (this.global) {
+        result += 'g';
+      }
+      if (this.ignoreCase) {
+        result += 'i';
+      }
+      if (this.multiline) {
+        result += 'm';
+      }
+      if (this.unicode) {
+        result += 'u';
+      }
+      if (this.sticky) {
+        result += 'y';
       }
       return result;
     };
 
-    var emulateES6construct = function (o) {
-      if (!ES.TypeIsObject(o)) throw new TypeError('bad object');
-      // es5 approximation to es6 subclass semantics: in es6, 'new Foo'
-      // would invoke Foo.@@create to allocation/initialize the new object.
-      // In es5 we just get the plain object.  So if we detect an
-      // uninitialized object, invoke o.constructor.@@create
-      if (!o._es6construct) {
-        if (o.constructor && ES.IsCallable(o.constructor['@@create'])) {
-          o = o.constructor['@@create'](o);
-        }
-        defineProperties(o, { _es6construct: true });
+    Value.getter(RegExp.prototype, 'flags', regExpFlagsGetter);
+  }
+
+  var regExpSupportsFlagsWithRegex = supportsDescriptors && valueOrFalseIfThrows(function () {
+    return String(new RegExp(/a/g, 'i')) === '/a/i';
+  });
+  var regExpNeedsToSupportSymbolMatch = hasSymbols && supportsDescriptors && (function () {
+    // Edge 0.12 supports flags fully, but does not support Symbol.match
+    var regex = /./;
+    regex[Symbol.match] = false;
+    return RegExp(regex) === regex;
+  }());
+
+  var regexToStringIsGeneric = valueOrFalseIfThrows(function () {
+    return RegExp.prototype.toString.call({ source: 'abc' }) === '/abc/';
+  });
+  var regexToStringSupportsGenericFlags = regexToStringIsGeneric && valueOrFalseIfThrows(function () {
+    return RegExp.prototype.toString.call({ source: 'a', flags: 'b' }) === '/a/b';
+  });
+  if (!regexToStringIsGeneric || !regexToStringSupportsGenericFlags) {
+    var origRegExpToString = RegExp.prototype.toString;
+    defineProperty(RegExp.prototype, 'toString', function toString() {
+      var R = ES.RequireObjectCoercible(this);
+      if (Type.regex(R)) {
+        return _call(origRegExpToString, R);
       }
-      return o;
-    };
+      var pattern = $String(R.source);
+      var flags = $String(R.flags);
+      return '/' + pattern + '/' + flags;
+    }, true);
+    Value.preserveToString(RegExp.prototype.toString, origRegExpToString);
+  }
 
-    var ES = {
-      CheckObjectCoercible: function (x, optMessage) {
-        /* jshint eqnull:true */
-        if (x == null)
-          throw new TypeError(optMessage || ('Cannot call method on ' + x));
-        return x;
-      },
+  if (supportsDescriptors && (!regExpSupportsFlagsWithRegex || regExpNeedsToSupportSymbolMatch)) {
+    var flagsGetter = Object.getOwnPropertyDescriptor(RegExp.prototype, 'flags').get;
+    var sourceDesc = Object.getOwnPropertyDescriptor(RegExp.prototype, 'source') || {};
+    var legacySourceGetter = function () { return this.source; }; // prior to it being a getter, it's own + nonconfigurable
+    var sourceGetter = ES.IsCallable(sourceDesc.get) ? sourceDesc.get : legacySourceGetter;
 
-      TypeIsObject: function (x) {
-        /* jshint eqnull:true */
-        // this is expensive when it returns false; use this function
-        // when you expect it to return true in the common case.
-        return x != null && Object(x) === x;
-      },
-
-      ToObject: function (o, optMessage) {
-        return Object(ES.CheckObjectCoercible(o, optMessage));
-      },
-
-      IsCallable: function (x) {
-        return typeof x === 'function' &&
-          // some versions of IE say that typeof /abc/ === 'function'
-          _toString.call(x) === '[object Function]';
-      },
-
-      ToInt32: function (x) {
-        return x >> 0;
-      },
-
-      ToUint32: function (x) {
-        return x >>> 0;
-      },
-
-      ToInteger: function (value) {
-        var number = +value;
-        if (Number.isNaN(number)) return 0;
-        if (number === 0 || !Number.isFinite(number)) return number;
-        return (number > 0 ? 1 : -1) * Math.floor(Math.abs(number));
-      },
-
-      ToLength: function (value) {
-        var len = ES.ToInteger(value);
-        if (len <= 0) return 0; // includes converting -0 to +0
-        if (len > Number.MAX_SAFE_INTEGER) return Number.MAX_SAFE_INTEGER;
-        return len;
-      },
-
-      SameValue: function (a, b) {
-        if (a === b) {
-          // 0 === -0, but they are not identical.
-          if (a === 0) return 1 / a === 1 / b;
-          return true;
-        }
-        return Number.isNaN(a) && Number.isNaN(b);
-      },
-
-      SameValueZero: function (a, b) {
-        // same as SameValue except for SameValueZero(+0, -0) == true
-        return (a === b) || (Number.isNaN(a) && Number.isNaN(b));
-      },
-
-      IsIterable: function (o) {
-        return ES.TypeIsObject(o) &&
-          (o[$iterator$] !== undefined || isArguments(o));
-      },
-
-      GetIterator: function (o) {
-        if (isArguments(o)) {
-          // special case support for `arguments`
-          return new ArrayIterator(o, "value");
-        }
-        var it = o[$iterator$]();
-        if (!ES.TypeIsObject(it)) {
-          throw new TypeError('bad iterator');
-        }
-        return it;
-      },
-
-      IteratorNext: function (it) {
-        var result = arguments.length > 1 ? it.next(arguments[1]) : it.next();
-        if (!ES.TypeIsObject(result)) {
-          throw new TypeError('bad iterator');
-        }
-        return result;
-      },
-
-      Construct: function (C, args) {
-        // CreateFromConstructor
-        var obj;
-        if (ES.IsCallable(C['@@create'])) {
-          obj = C['@@create']();
-        } else {
-          // OrdinaryCreateFromConstructor
-          obj = create(C.prototype || null);
-        }
-        // Mark that we've used the es6 construct path
-        // (see emulateES6construct)
-        defineProperties(obj, { _es6construct: true });
-        // Call the constructor.
-        var result = C.apply(obj, args);
-        return ES.TypeIsObject(result) ? result : obj;
-      }
-    };
-
-    var numberConversion = (function () {
-      // from https://github.com/inexorabletash/polyfill/blob/master/typedarray.js#L176-L266
-      // with permission and license, per https://twitter.com/inexorabletash/status/372206509540659200
-
-      function roundToEven(n) {
-        var w = Math.floor(n), f = n - w;
-        if (f < 0.5) {
-          return w;
-        }
-        if (f > 0.5) {
-          return w + 1;
-        }
-        return w % 2 ? w + 1 : w;
-      }
-
-      function packIEEE754(v, ebits, fbits) {
-        var bias = (1 << (ebits - 1)) - 1,
-          s, e, f, ln,
-          i, bits, str, bytes;
-
-        // Compute sign, exponent, fraction
-        if (v !== v) {
-          // NaN
-          // http://dev.w3.org/2006/webapi/WebIDL/#es-type-mapping
-          e = (1 << ebits) - 1;
-          f = Math.pow(2, fbits - 1);
-          s = 0;
-        } else if (v === Infinity || v === -Infinity) {
-          e = (1 << ebits) - 1;
-          f = 0;
-          s = (v < 0) ? 1 : 0;
-        } else if (v === 0) {
-          e = 0;
-          f = 0;
-          s = (1 / v === -Infinity) ? 1 : 0;
-        } else {
-          s = v < 0;
-          v = Math.abs(v);
-
-          if (v >= Math.pow(2, 1 - bias)) {
-            e = Math.min(Math.floor(Math.log(v) / Math.LN2), 1023);
-            f = roundToEven(v / Math.pow(2, e) * Math.pow(2, fbits));
-            if (f / Math.pow(2, fbits) >= 2) {
-              e = e + 1;
-              f = 1;
-            }
-            if (e > bias) {
-              // Overflow
-              e = (1 << ebits) - 1;
-              f = 0;
-            } else {
-              // Normal
-              e = e + bias;
-              f = f - Math.pow(2, fbits);
-            }
-          } else {
-            // Subnormal
-            e = 0;
-            f = roundToEven(v / Math.pow(2, 1 - bias - fbits));
-          }
+    var OrigRegExp = RegExp;
+    var RegExpShim = (function () {
+      return function RegExp(pattern, flags) {
+        var patternIsRegExp = ES.IsRegExp(pattern);
+        var calledWithNew = this instanceof RegExp;
+        if (!calledWithNew && patternIsRegExp && typeof flags === 'undefined' && pattern.constructor === RegExp) {
+          return pattern;
         }
 
-        // Pack sign, exponent, fraction
-        bits = [];
-        for (i = fbits; i; i -= 1) {
-          bits.push(f % 2 ? 1 : 0);
-          f = Math.floor(f / 2);
+        var P = pattern;
+        var F = flags;
+        if (Type.regex(pattern)) {
+          P = ES.Call(sourceGetter, pattern);
+          F = typeof flags === 'undefined' ? ES.Call(flagsGetter, pattern) : flags;
+          return new RegExp(P, F);
+        } else if (patternIsRegExp) {
+          P = pattern.source;
+          F = typeof flags === 'undefined' ? pattern.flags : flags;
         }
-        for (i = ebits; i; i -= 1) {
-          bits.push(e % 2 ? 1 : 0);
-          e = Math.floor(e / 2);
-        }
-        bits.push(s ? 1 : 0);
-        bits.reverse();
-        str = bits.join('');
-
-        // Bits to bytes
-        bytes = [];
-        while (str.length) {
-          bytes.push(parseInt(str.slice(0, 8), 2));
-          str = str.slice(8);
-        }
-        return bytes;
-      }
-
-      function unpackIEEE754(bytes, ebits, fbits) {
-        // Bytes to bits
-        var bits = [], i, j, b, str,
-            bias, s, e, f;
-
-        for (i = bytes.length; i; i -= 1) {
-          b = bytes[i - 1];
-          for (j = 8; j; j -= 1) {
-            bits.push(b % 2 ? 1 : 0);
-            b = b >> 1;
-          }
-        }
-        bits.reverse();
-        str = bits.join('');
-
-        // Unpack sign, exponent, fraction
-        bias = (1 << (ebits - 1)) - 1;
-        s = parseInt(str.slice(0, 1), 2) ? -1 : 1;
-        e = parseInt(str.slice(1, 1 + ebits), 2);
-        f = parseInt(str.slice(1 + ebits), 2);
-
-        // Produce number
-        if (e === (1 << ebits) - 1) {
-          return f !== 0 ? NaN : s * Infinity;
-        } else if (e > 0) {
-          // Normalized
-          return s * Math.pow(2, e - bias) * (1 + f / Math.pow(2, fbits));
-        } else if (f !== 0) {
-          // Denormalized
-          return s * Math.pow(2, -(bias - 1)) * (f / Math.pow(2, fbits));
-        } else {
-          return s < 0 ? -0 : 0;
-        }
-      }
-
-      function unpackFloat64(b) { return unpackIEEE754(b, 11, 52); }
-      function packFloat64(v) { return packIEEE754(v, 11, 52); }
-      function unpackFloat32(b) { return unpackIEEE754(b, 8, 23); }
-      function packFloat32(v) { return packIEEE754(v, 8, 23); }
-
-      var conversions = {
-        toFloat32: function (num) { return unpackFloat32(packFloat32(num)); }
+        return new OrigRegExp(pattern, flags);
       };
-      if (typeof Float32Array !== 'undefined') {
-        var float32array = new Float32Array(1);
-        conversions.toFloat32 = function (num) {
-          float32array[0] = num;
-          return float32array[0];
-        };
-      }
-      return conversions;
     }());
+    wrapConstructor(OrigRegExp, RegExpShim, {
+      $input: true // Chrome < v39 & Opera < 26 have a nonstandard "$input" property
+    });
+    /* globals RegExp: true */
+    /* eslint-disable no-undef */
+    /* jshint -W020 */
+    RegExp = RegExpShim;
+    Value.redefine(globals, 'RegExp', RegExpShim);
+    /* jshint +W020 */
+    /* eslint-enable no-undef */
+    /* globals RegExp: false */
+  }
 
-    defineProperties(String, {
-      fromCodePoint: function (_) { // length = 1
-        var points = _slice.call(arguments, 0, arguments.length);
-        var result = [];
-        var next;
-        for (var i = 0, length = points.length; i < length; i++) {
-          next = Number(points[i]);
-          if (!ES.SameValue(next, ES.ToInteger(next)) ||
-              next < 0 || next > 0x10FFFF) {
-            throw new RangeError('Invalid code point ' + next);
-          }
-
-          if (next < 0x10000) {
-            result.push(String.fromCharCode(next));
-          } else {
-            next -= 0x10000;
-            result.push(String.fromCharCode((next >> 10) + 0xD800));
-            result.push(String.fromCharCode((next % 0x400) + 0xDC00));
-          }
-        }
-        return result.join('');
-      },
-
-      raw: function (callSite) { // raw.length===1
-        var substitutions = _slice.call(arguments, 1, arguments.length);
-        var cooked = ES.ToObject(callSite, 'bad callSite');
-        var rawValue = cooked.raw;
-        var raw = ES.ToObject(rawValue, 'bad raw value');
-        var len = Object.keys(raw).length;
-        var literalsegments = ES.ToLength(len);
-        if (literalsegments === 0) {
-          return '';
-        }
-
-        var stringElements = [];
-        var nextIndex = 0;
-        var nextKey, next, nextSeg, nextSub;
-        while (nextIndex < literalsegments) {
-          nextKey = String(nextIndex);
-          next = raw[nextKey];
-          nextSeg = String(next);
-          stringElements.push(nextSeg);
-          if (nextIndex + 1 >= literalsegments) {
-            break;
-          }
-          next = substitutions[nextKey];
-          if (next === undefined) {
-            break;
-          }
-          nextSub = String(next);
-          stringElements.push(nextSub);
-          nextIndex++;
-        }
-        return stringElements.join('');
+  if (supportsDescriptors) {
+    var regexGlobals = {
+      input: '$_',
+      lastMatch: '$&',
+      lastParen: '$+',
+      leftContext: '$`',
+      rightContext: '$\''
+    };
+    _forEach(keys(regexGlobals), function (prop) {
+      if (prop in RegExp && !(regexGlobals[prop] in RegExp)) {
+        Value.getter(RegExp, regexGlobals[prop], function get() {
+          return RegExp[prop];
+        });
       }
     });
+  }
+  addDefaultSpecies(RegExp);
 
-    // Firefox 31 reports this function's length as 0
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1062484
-    if (String.fromCodePoint.length !== 1) {
-      var originalFromCodePoint = String.fromCodePoint;
-      defineProperty(String, 'fromCodePoint', function (_) { return originalFromCodePoint.apply(this, arguments); }, true);
-    }
+  var inverseEpsilon = 1 / Number.EPSILON;
+  var roundTiesToEven = function roundTiesToEven(n) {
+    // Even though this reduces down to `return n`, it takes advantage of built-in rounding.
+    return (n + inverseEpsilon) - inverseEpsilon;
+  };
+  var BINARY_32_EPSILON = Math.pow(2, -23);
+  var BINARY_32_MAX_VALUE = Math.pow(2, 127) * (2 - BINARY_32_EPSILON);
+  var BINARY_32_MIN_VALUE = Math.pow(2, -126);
+  var E = Math.E;
+  var LOG2E = Math.LOG2E;
+  var LOG10E = Math.LOG10E;
+  var numberCLZ = Number.prototype.clz;
+  delete Number.prototype.clz; // Safari 8 has Number#clz
 
-    var StringShims = {
-      // Fast repeat, uses the `Exponentiation by squaring` algorithm.
-      // Perf: http://jsperf.com/string-repeat2/2
-      repeat: (function () {
-        var repeat = function (s, times) {
-          if (times < 1) return '';
-          if (times % 2) return repeat(s, times - 1) + s;
-          var half = repeat(s, times / 2);
-          return half + half;
-        };
+  var MathShims = {
+    acosh: function acosh(value) {
+      var x = Number(value);
+      if (numberIsNaN(x) || value < 1) { return NaN; }
+      if (x === 1) { return 0; }
+      if (x === Infinity) { return x; }
+      return _log(x / E + _sqrt(x + 1) * _sqrt(x - 1) / E) + 1;
+    },
 
-        return function (times) {
-          var thisStr = String(ES.CheckObjectCoercible(this));
-          times = ES.ToInteger(times);
-          if (times < 0 || times === Infinity) {
-            throw new RangeError('Invalid String#repeat value');
-          }
-          return repeat(thisStr, times);
-        };
-      })(),
-
-      startsWith: function (searchStr) {
-        var thisStr = String(ES.CheckObjectCoercible(this));
-        if (_toString.call(searchStr) === '[object RegExp]') throw new TypeError('Cannot call method "startsWith" with a regex');
-        searchStr = String(searchStr);
-        var startArg = arguments.length > 1 ? arguments[1] : undefined;
-        var start = Math.max(ES.ToInteger(startArg), 0);
-        return thisStr.slice(start, start + searchStr.length) === searchStr;
-      },
-
-      endsWith: function (searchStr) {
-        var thisStr = String(ES.CheckObjectCoercible(this));
-        if (_toString.call(searchStr) === '[object RegExp]') throw new TypeError('Cannot call method "endsWith" with a regex');
-        searchStr = String(searchStr);
-        var thisLen = thisStr.length;
-        var posArg = arguments.length > 1 ? arguments[1] : undefined;
-        var pos = posArg === undefined ? thisLen : ES.ToInteger(posArg);
-        var end = Math.min(Math.max(pos, 0), thisLen);
-        return thisStr.slice(end - searchStr.length, end) === searchStr;
-      },
-
-      contains: function (searchString) {
-        var position = arguments.length > 1 ? arguments[1] : undefined;
-        // Somehow this trick makes method 100% compat with the spec.
-        return _indexOf.call(this, searchString, position) !== -1;
-      },
-
-      codePointAt: function (pos) {
-        var thisStr = String(ES.CheckObjectCoercible(this));
-        var position = ES.ToInteger(pos);
-        var length = thisStr.length;
-        if (position < 0 || position >= length) return undefined;
-        var first = thisStr.charCodeAt(position);
-        var isEnd = (position + 1 === length);
-        if (first < 0xD800 || first > 0xDBFF || isEnd) return first;
-        var second = thisStr.charCodeAt(position + 1);
-        if (second < 0xDC00 || second > 0xDFFF) return first;
-        return ((first - 0xD800) * 1024) + (second - 0xDC00) + 0x10000;
+    asinh: function asinh(value) {
+      var x = Number(value);
+      if (x === 0 || !globalIsFinite(x)) {
+        return x;
       }
-    };
-    defineProperties(String.prototype, StringShims);
+      return x < 0 ? -asinh(-x) : _log(x + _sqrt(x * x + 1));
+    },
 
-    var hasStringTrimBug = '\u0085'.trim().length !== 1;
-    if (hasStringTrimBug) {
-      var originalStringTrim = String.prototype.trim;
-      delete String.prototype.trim;
-      // whitespace from: http://es5.github.io/#x15.5.4.20
-      // implementation from https://github.com/es-shims/es5-shim/blob/v3.4.0/es5-shim.js#L1304-L1324
-      var ws = [
-        '\x09\x0A\x0B\x0C\x0D\x20\xA0\u1680\u180E\u2000\u2001\u2002\u2003',
-        '\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028',
-        '\u2029\uFEFF'
-      ].join('');
-      var trimRegexp = new RegExp('(^[' + ws + ']+)|([' + ws + ']+$)', 'g');
-      defineProperties(String.prototype, {
-        trim: function () {
-          if (this === undefined || this === null) {
-            throw new TypeError("can't convert " + this + " to object");
-          }
-          return String(this).replace(trimRegexp, "");
-        }
-      });
-    }
-
-    // see https://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype-@@iterator
-    var StringIterator = function (s) {
-      this._s = String(ES.CheckObjectCoercible(s));
-      this._i = 0;
-    };
-    StringIterator.prototype.next = function () {
-      var s = this._s, i = this._i;
-      if (s === undefined || i >= s.length) {
-        this._s = undefined;
-        return { value: undefined, done: true };
+    atanh: function atanh(value) {
+      var x = Number(value);
+      if (numberIsNaN(x) || x < -1 || x > 1) {
+        return NaN;
       }
-      var first = s.charCodeAt(i), second, len;
-      if (first < 0xD800 || first > 0xDBFF || (i + 1) == s.length) {
-        len = 1;
+      if (x === -1) { return -Infinity; }
+      if (x === 1) { return Infinity; }
+      if (x === 0) { return x; }
+      return 0.5 * _log((1 + x) / (1 - x));
+    },
+
+    cbrt: function cbrt(value) {
+      var x = Number(value);
+      if (x === 0) { return x; }
+      var negate = x < 0;
+      var result;
+      if (negate) { x = -x; }
+      if (x === Infinity) {
+        result = Infinity;
       } else {
-        second = s.charCodeAt(i + 1);
-        len = (second < 0xDC00 || second > 0xDFFF) ? 1 : 2;
+        result = _exp(_log(x) / 3);
+        // from http://en.wikipedia.org/wiki/Cube_root#Numerical_methods
+        result = (x / (result * result) + (2 * result)) / 3;
       }
-      this._i = i + len;
-      return { value: s.substr(i, len), done: false };
-    };
-    addIterator(StringIterator.prototype);
-    addIterator(String.prototype, function () {
-      return new StringIterator(this);
-    });
+      return negate ? -result : result;
+    },
 
-    if (!startsWithIsCompliant) {
-      // Firefox has a noncompliant startsWith implementation
-      String.prototype.startsWith = StringShims.startsWith;
-      String.prototype.endsWith = StringShims.endsWith;
-    }
+    clz32: function clz32(value) {
+      // See https://bugs.ecmascript.org/show_bug.cgi?id=2465
+      var x = Number(value);
+      var number = ES.ToUint32(x);
+      if (number === 0) {
+        return 32;
+      }
+      return numberCLZ ? ES.Call(numberCLZ, number) : 31 - _floor(_log(number + 0.5) * LOG2E);
+    },
 
-    var ArrayShims = {
-      from: function (iterable) {
-        var mapFn = arguments.length > 1 ? arguments[1] : undefined;
+    cosh: function cosh(value) {
+      var x = Number(value);
+      if (x === 0) { return 1; } // +0 or -0
+      if (numberIsNaN(x)) { return NaN; }
+      if (!globalIsFinite(x)) { return Infinity; }
+      if (x < 0) { x = -x; }
+      if (x > 21) { return _exp(x) / 2; }
+      return (_exp(x) + _exp(-x)) / 2;
+    },
 
-        var list = ES.ToObject(iterable, 'bad iterable');
-        if (mapFn !== undefined && !ES.IsCallable(mapFn)) {
-          throw new TypeError('Array.from: when provided, the second argument must be a function');
-        }
+    expm1: function expm1(value) {
+      var x = Number(value);
+      if (x === -Infinity) { return -1; }
+      if (!globalIsFinite(x) || x === 0) { return x; }
+      if (_abs(x) > 0.5) {
+        return _exp(x) - 1;
+      }
+      // A more precise approximation using Taylor series expansion
+      // from https://github.com/paulmillr/es6-shim/issues/314#issuecomment-70293986
+      var t = x;
+      var sum = 0;
+      var n = 1;
+      while (sum + t !== sum) {
+        sum += t;
+        n += 1;
+        t *= x / n;
+      }
+      return sum;
+    },
 
-        var hasThisArg = arguments.length > 2;
-        var thisArg = hasThisArg ? arguments[2] : undefined;
-
-        var usingIterator = ES.IsIterable(list);
-        // does the spec really mean that Arrays should use ArrayIterator?
-        // https://bugs.ecmascript.org/show_bug.cgi?id=2416
-        //if (Array.isArray(list)) { usingIterator=false; }
-
-        var length;
-        var result, i, value;
-        if (usingIterator) {
-          i = 0;
-          result = ES.IsCallable(this) ? Object(new this()) : [];
-          var it = usingIterator ? ES.GetIterator(list) : null;
-          var iterationValue;
-
-          do {
-            iterationValue = ES.IteratorNext(it);
-            if (!iterationValue.done) {
-              value = iterationValue.value;
-              if (mapFn) {
-                result[i] = hasThisArg ? mapFn.call(thisArg, value, i) : mapFn(value, i);
-              } else {
-                result[i] = value;
-              }
-              i += 1;
-            }
-          } while (!iterationValue.done);
-          length = i;
+    hypot: function hypot(x, y) {
+      var result = 0;
+      var largest = 0;
+      for (var i = 0; i < arguments.length; ++i) {
+        var value = _abs(Number(arguments[i]));
+        if (largest < value) {
+          result *= (largest / value) * (largest / value);
+          result += 1;
+          largest = value;
         } else {
-          length = ES.ToLength(list.length);
-          result = ES.IsCallable(this) ? Object(new this(length)) : new Array(length);
-          for (i = 0; i < length; ++i) {
-            value = list[i];
-            if (mapFn) {
-              result[i] = hasThisArg ? mapFn.call(thisArg, value, i) : mapFn(value, i);
-            } else {
-              result[i] = value;
-            }
-          }
+          result += value > 0 ? (value / largest) * (value / largest) : value;
         }
-
-        result.length = length;
-        return result;
-      },
-
-      of: function () {
-        return Array.from(arguments);
       }
-    };
-    defineProperties(Array, ArrayShims);
+      return largest === Infinity ? Infinity : largest * _sqrt(result);
+    },
 
-    var arrayFromSwallowsNegativeLengths = function () {
-      try {
-        return Array.from({ length: -1 }).length === 0;
-      } catch (e) {
+    log2: function log2(value) {
+      return _log(value) * LOG2E;
+    },
+
+    log10: function log10(value) {
+      return _log(value) * LOG10E;
+    },
+
+    log1p: function log1p(value) {
+      var x = Number(value);
+      if (x < -1 || numberIsNaN(x)) { return NaN; }
+      if (x === 0 || x === Infinity) { return x; }
+      if (x === -1) { return -Infinity; }
+
+      return (1 + x) - 1 === 0 ? x : x * (_log(1 + x) / ((1 + x) - 1));
+    },
+
+    sign: _sign,
+
+    sinh: function sinh(value) {
+      var x = Number(value);
+      if (!globalIsFinite(x) || x === 0) { return x; }
+
+      if (_abs(x) < 1) {
+        return (Math.expm1(x) - Math.expm1(-x)) / 2;
+      }
+      return (_exp(x - 1) - _exp(-x - 1)) * E / 2;
+    },
+
+    tanh: function tanh(value) {
+      var x = Number(value);
+      if (numberIsNaN(x) || x === 0) { return x; }
+      // can exit early at +-20 as JS loses precision for true value at this integer
+      if (x >= 20) { return 1; }
+      if (x <= -20) { return -1; }
+
+      return (Math.expm1(x) - Math.expm1(-x)) / (_exp(x) + _exp(-x));
+    },
+
+    trunc: function trunc(value) {
+      var x = Number(value);
+      return x < 0 ? -_floor(-x) : _floor(x);
+    },
+
+    imul: function imul(x, y) {
+      // taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul
+      var a = ES.ToUint32(x);
+      var b = ES.ToUint32(y);
+      var ah = (a >>> 16) & 0xffff;
+      var al = a & 0xffff;
+      var bh = (b >>> 16) & 0xffff;
+      var bl = b & 0xffff;
+      // the shift by 0 fixes the sign on the high part
+      // the final |0 converts the unsigned value into a signed value
+      return (al * bl) + (((ah * bl + al * bh) << 16) >>> 0) | 0;
+    },
+
+    fround: function fround(x) {
+      var v = Number(x);
+      if (v === 0 || v === Infinity || v === -Infinity || numberIsNaN(v)) {
+        return v;
+      }
+      var sign = _sign(v);
+      var abs = _abs(v);
+      if (abs < BINARY_32_MIN_VALUE) {
+        return sign * roundTiesToEven(abs / BINARY_32_MIN_VALUE / BINARY_32_EPSILON) * BINARY_32_MIN_VALUE * BINARY_32_EPSILON;
+      }
+      // Veltkamp's splitting (?)
+      var a = (1 + BINARY_32_EPSILON / Number.EPSILON) * abs;
+      var result = a - (a - abs);
+      if (result > BINARY_32_MAX_VALUE || numberIsNaN(result)) {
+        return sign * Infinity;
+      }
+      return sign * result;
+    }
+  };
+  defineProperties(Math, MathShims);
+  // IE 11 TP has an imprecise log1p: reports Math.log1p(-1e-17) as 0
+  defineProperty(Math, 'log1p', MathShims.log1p, Math.log1p(-1e-17) !== -1e-17);
+  // IE 11 TP has an imprecise asinh: reports Math.asinh(-1e7) as not exactly equal to -Math.asinh(1e7)
+  defineProperty(Math, 'asinh', MathShims.asinh, Math.asinh(-1e7) !== -Math.asinh(1e7));
+  // Chrome 40 has an imprecise Math.tanh with very small numbers
+  defineProperty(Math, 'tanh', MathShims.tanh, Math.tanh(-2e-17) !== -2e-17);
+  // Chrome 40 loses Math.acosh precision with high numbers
+  defineProperty(Math, 'acosh', MathShims.acosh, Math.acosh(Number.MAX_VALUE) === Infinity);
+  // Firefox 38 on Windows
+  defineProperty(Math, 'cbrt', MathShims.cbrt, Math.abs(1 - Math.cbrt(1e-300) / 1e-100) / Number.EPSILON > 8);
+  // node 0.11 has an imprecise Math.sinh with very small numbers
+  defineProperty(Math, 'sinh', MathShims.sinh, Math.sinh(-2e-17) !== -2e-17);
+  // FF 35 on Linux reports 22025.465794806725 for Math.expm1(10)
+  var expm1OfTen = Math.expm1(10);
+  defineProperty(Math, 'expm1', MathShims.expm1, expm1OfTen > 22025.465794806719 || expm1OfTen < 22025.4657948067165168);
+
+  var origMathRound = Math.round;
+  // breaks in e.g. Safari 8, Internet Explorer 11, Opera 12
+  var roundHandlesBoundaryConditions = Math.round(0.5 - Number.EPSILON / 4) === 0 && Math.round(-0.5 + Number.EPSILON / 3.99) === 1;
+
+  // When engines use Math.floor(x + 0.5) internally, Math.round can be buggy for large integers.
+  // This behavior should be governed by "round to nearest, ties to even mode"
+  // see http://www.ecma-international.org/ecma-262/6.0/#sec-terms-and-definitions-number-type
+  // These are the boundary cases where it breaks.
+  var smallestPositiveNumberWhereRoundBreaks = inverseEpsilon + 1;
+  var largestPositiveNumberWhereRoundBreaks = 2 * inverseEpsilon - 1;
+  var roundDoesNotIncreaseIntegers = [smallestPositiveNumberWhereRoundBreaks, largestPositiveNumberWhereRoundBreaks].every(function (num) {
+    return Math.round(num) === num;
+  });
+  defineProperty(Math, 'round', function round(x) {
+    var floor = _floor(x);
+    var ceil = floor === -1 ? -0 : floor + 1;
+    return x - floor < 0.5 ? floor : ceil;
+  }, !roundHandlesBoundaryConditions || !roundDoesNotIncreaseIntegers);
+  Value.preserveToString(Math.round, origMathRound);
+
+  var origImul = Math.imul;
+  if (Math.imul(0xffffffff, 5) !== -5) {
+    // Safari 6.1, at least, reports "0" for this value
+    Math.imul = MathShims.imul;
+    Value.preserveToString(Math.imul, origImul);
+  }
+  if (Math.imul.length !== 2) {
+    // Safari 8.0.4 has a length of 1
+    // fixed in https://bugs.webkit.org/show_bug.cgi?id=143658
+    overrideNative(Math, 'imul', function imul(x, y) {
+      return ES.Call(origImul, Math, arguments);
+    });
+  }
+
+  // Promises
+  // Simplest possible implementation; use a 3rd-party library if you
+  // want the best possible speed and/or long stack traces.
+  var PromiseShim = (function () {
+    var setTimeout = globals.setTimeout;
+    // some environments don't have setTimeout - no way to shim here.
+    if (typeof setTimeout !== 'function' && typeof setTimeout !== 'object') { return; }
+
+    ES.IsPromise = function (promise) {
+      if (!ES.TypeIsObject(promise)) {
         return false;
       }
-    };
-    // Fixes a Firefox bug in v32
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=1063993
-    if (!arrayFromSwallowsNegativeLengths()) {
-      defineProperty(Array, 'from', ArrayShims.from, true);
-    }
-
-    // Our ArrayIterator is private; see
-    // https://github.com/paulmillr/es6-shim/issues/252
-    ArrayIterator = function (array, kind) {
-        this.i = 0;
-        this.array = array;
-        this.kind = kind;
+      if (typeof promise._promise === 'undefined') {
+        return false; // uninitialized, or missing our hidden field.
+      }
+      return true;
     };
 
-    defineProperties(ArrayIterator.prototype, {
-      next: function () {
-        var i = this.i, array = this.array;
-        if (!(this instanceof ArrayIterator)) {
-          throw new TypeError('Not an ArrayIterator');
-        }
-        if (array !== undefined) {
-          var len = ES.ToLength(array.length);
-          for (; i < len; i++) {
-            var kind = this.kind;
-            var retval;
-            if (kind === "key") {
-              retval = i;
-            } else if (kind === "value") {
-              retval = array[i];
-            } else if (kind === "entry") {
-              retval = [i, array[i]];
-            }
-            this.i = i + 1;
-            return { value: retval, done: false };
-          }
-        }
-        this.array = undefined;
-        return { value: undefined, done: true };
+    // "PromiseCapability" in the spec is what most promise implementations
+    // call a "deferred".
+    var PromiseCapability = function (C) {
+      if (!ES.IsConstructor(C)) {
+        throw new TypeError('Bad promise constructor');
       }
-    });
-    addIterator(ArrayIterator.prototype);
-
-    var ArrayPrototypeShims = {
-      copyWithin: function (target, start) {
-        var end = arguments[2]; // copyWithin.length must be 2
-        var o = ES.ToObject(this);
-        var len = ES.ToLength(o.length);
-        target = ES.ToInteger(target);
-        start = ES.ToInteger(start);
-        var to = target < 0 ? Math.max(len + target, 0) : Math.min(target, len);
-        var from = start < 0 ? Math.max(len + start, 0) : Math.min(start, len);
-        end = end === undefined ? len : ES.ToInteger(end);
-        var fin = end < 0 ? Math.max(len + end, 0) : Math.min(end, len);
-        var count = Math.min(fin - from, len - to);
-        var direction = 1;
-        if (from < to && to < (from + count)) {
-          direction = -1;
-          from += count - 1;
-          to += count - 1;
+      var capability = this;
+      var resolver = function (resolve, reject) {
+        if (capability.resolve !== void 0 || capability.reject !== void 0) {
+          throw new TypeError('Bad Promise implementation!');
         }
-        while (count > 0) {
-          if (_hasOwnProperty.call(o, from)) {
-            o[to] = o[from];
-          } else {
-            delete o[from];
-          }
-          from += direction;
-          to += direction;
-          count -= 1;
-        }
-        return o;
-      },
-
-      fill: function (value) {
-        var start = arguments.length > 1 ? arguments[1] : undefined;
-        var end = arguments.length > 2 ? arguments[2] : undefined;
-        var O = ES.ToObject(this);
-        var len = ES.ToLength(O.length);
-        start = ES.ToInteger(start === undefined ? 0 : start);
-        end = ES.ToInteger(end === undefined ? len : end);
-
-        var relativeStart = start < 0 ? Math.max(len + start, 0) : Math.min(start, len);
-        var relativeEnd = end < 0 ? len + end : end;
-
-        for (var i = relativeStart; i < len && i < relativeEnd; ++i) {
-          O[i] = value;
-        }
-        return O;
-      },
-
-      find: function find(predicate) {
-        var list = ES.ToObject(this);
-        var length = ES.ToLength(list.length);
-        if (!ES.IsCallable(predicate)) {
-          throw new TypeError('Array#find: predicate must be a function');
-        }
-        var thisArg = arguments[1];
-        for (var i = 0, value; i < length; i++) {
-          value = list[i];
-          if (predicate.call(thisArg, value, i, list)) { return value; }
-        }
-        return undefined;
-      },
-
-      findIndex: function findIndex(predicate) {
-        var list = ES.ToObject(this);
-        var length = ES.ToLength(list.length);
-        if (!ES.IsCallable(predicate)) {
-          throw new TypeError('Array#findIndex: predicate must be a function');
-        }
-        var thisArg = arguments[1];
-        for (var i = 0; i < length; i++) {
-          if (predicate.call(thisArg, list[i], i, list)) { return i; }
-        }
-        return -1;
-      },
-
-      keys: function () {
-        return new ArrayIterator(this, "key");
-      },
-
-      values: function () {
-        return new ArrayIterator(this, "value");
-      },
-
-      entries: function () {
-        return new ArrayIterator(this, "entry");
+        capability.resolve = resolve;
+        capability.reject = reject;
+      };
+      // Initialize fields to inform optimizers about the object shape.
+      capability.resolve = void 0;
+      capability.reject = void 0;
+      capability.promise = new C(resolver);
+      if (!(ES.IsCallable(capability.resolve) && ES.IsCallable(capability.reject))) {
+        throw new TypeError('Bad promise constructor');
       }
     };
-    // Safari 7.1 defines Array#keys and Array#entries natively,
-    // but the resulting ArrayIterator objects don't have a "next" method.
-    if (Array.prototype.keys && !ES.IsCallable([1].keys().next)) {
-      delete Array.prototype.keys;
-    }
-    if (Array.prototype.entries && !ES.IsCallable([1].entries().next)) {
-      delete Array.prototype.entries;
-    }
-    defineProperties(Array.prototype, ArrayPrototypeShims);
 
-    addIterator(Array.prototype, function () { return this.values(); });
-    // Chrome defines keys/values/entries on Array, but doesn't give us
-    // any way to identify its iterator.  So add our own shimmed field.
-    if (Object.getPrototypeOf) {
-      addIterator(Object.getPrototypeOf([].values()));
-    }
-
-    var maxSafeInteger = Math.pow(2, 53) - 1;
-    defineProperties(Number, {
-      MAX_SAFE_INTEGER: maxSafeInteger,
-      MIN_SAFE_INTEGER: -maxSafeInteger,
-      EPSILON: 2.220446049250313e-16,
-
-      parseInt: globals.parseInt,
-      parseFloat: globals.parseFloat,
-
-      isFinite: function (value) {
-        return typeof value === 'number' && global_isFinite(value);
-      },
-
-      isInteger: function (value) {
-        return Number.isFinite(value) &&
-          ES.ToInteger(value) === value;
-      },
-
-      isSafeInteger: function (value) {
-        return Number.isInteger(value) && Math.abs(value) <= Number.MAX_SAFE_INTEGER;
-      },
-
-      isNaN: function (value) {
-        // NaN !== NaN, but they are identical.
-        // NaNs are the only non-reflexive value, i.e., if x !== x,
-        // then x is NaN.
-        // isNaN is broken: it converts its argument to number, so
-        // isNaN('foo') => true
-        return value !== value;
-      }
-
-    });
-
-    // Work around bugs in Array#find and Array#findIndex -- early
-    // implementations skipped holes in sparse arrays. (Note that the
-    // implementations of find/findIndex indirectly use shimmed
-    // methods of Number, so this test has to happen down here.)
-    if (![, 1].find(function (item, idx) { return idx === 0; })) {
-      defineProperty(Array.prototype, 'find', ArrayPrototypeShims.find, true);
-    }
-    if ([, 1].findIndex(function (item, idx) { return idx === 0; }) !== 0) {
-      defineProperty(Array.prototype, 'findIndex', ArrayPrototypeShims.findIndex, true);
-    }
-
-    if (supportsDescriptors) {
-      defineProperties(Object, {
-        getPropertyDescriptor: function (subject, name) {
-          var pd = Object.getOwnPropertyDescriptor(subject, name);
-          var proto = Object.getPrototypeOf(subject);
-          while (pd === undefined && proto !== null) {
-            pd = Object.getOwnPropertyDescriptor(proto, name);
-            proto = Object.getPrototypeOf(proto);
+    // find an appropriate setImmediate-alike
+    var makeZeroTimeout;
+    /*global window */
+    if (typeof window !== 'undefined' && ES.IsCallable(window.postMessage)) {
+      makeZeroTimeout = function () {
+        // from http://dbaron.org/log/20100309-faster-timeouts
+        var timeouts = [];
+        var messageName = 'zero-timeout-message';
+        var setZeroTimeout = function (fn) {
+          _push(timeouts, fn);
+          window.postMessage(messageName, '*');
+        };
+        var handleMessage = function (event) {
+          if (event.source === window && event.data === messageName) {
+            event.stopPropagation();
+            if (timeouts.length === 0) { return; }
+            var fn = _shift(timeouts);
+            fn();
           }
-          return pd;
-        },
+        };
+        window.addEventListener('message', handleMessage, true);
+        return setZeroTimeout;
+      };
+    }
+    var makePromiseAsap = function () {
+      // An efficient task-scheduler based on a pre-existing Promise
+      // implementation, which we can use even if we override the
+      // global Promise below (in order to workaround bugs)
+      // https://github.com/Raynos/observ-hash/issues/2#issuecomment-35857671
+      var P = globals.Promise;
+      var pr = P && P.resolve && P.resolve();
+      return pr && function (task) {
+        return pr.then(task);
+      };
+    };
+    /*global process */
+    /* jscs:disable disallowMultiLineTernary */
+    var enqueue = ES.IsCallable(globals.setImmediate) ?
+      globals.setImmediate :
+      typeof process === 'object' && process.nextTick ? process.nextTick :
+      makePromiseAsap() ||
+      (ES.IsCallable(makeZeroTimeout) ? makeZeroTimeout() :
+      function (task) { setTimeout(task, 0); }); // fallback
+    /* jscs:enable disallowMultiLineTernary */
 
-        getPropertyNames: function (subject) {
-          var result = Object.getOwnPropertyNames(subject);
-          var proto = Object.getPrototypeOf(subject);
+    // Constants for Promise implementation
+    var PROMISE_IDENTITY = function (x) { return x; };
+    var PROMISE_THROWER = function (e) { throw e; };
+    var PROMISE_PENDING = 0;
+    var PROMISE_FULFILLED = 1;
+    var PROMISE_REJECTED = 2;
+    // We store fulfill/reject handlers and capabilities in a single array.
+    var PROMISE_FULFILL_OFFSET = 0;
+    var PROMISE_REJECT_OFFSET = 1;
+    var PROMISE_CAPABILITY_OFFSET = 2;
+    // This is used in an optimization for chaining promises via then.
+    var PROMISE_FAKE_CAPABILITY = {};
 
-          var addProperty = function (property) {
-            if (result.indexOf(property) === -1) {
-              result.push(property);
-            }
-          };
-
-          while (proto !== null) {
-            Object.getOwnPropertyNames(proto).forEach(addProperty);
-            proto = Object.getPrototypeOf(proto);
-          }
-          return result;
-        }
+    var enqueuePromiseReactionJob = function (handler, capability, argument) {
+      enqueue(function () {
+        promiseReactionJob(handler, capability, argument);
       });
-
-      defineProperties(Object, {
-        // 19.1.3.1
-        assign: function (target, source) {
-          if (!ES.TypeIsObject(target)) {
-            throw new TypeError('target must be an object');
-          }
-          return Array.prototype.reduce.call(arguments, function (target, source) {
-            return Object.keys(Object(source)).reduce(function (target, key) {
-              target[key] = source[key];
-              return target;
-            }, target);
-          });
-        },
-
-        is: function (a, b) {
-          return ES.SameValue(a, b);
-        },
-
-        // 19.1.3.9
-        // shim from https://gist.github.com/WebReflection/5593554
-        setPrototypeOf: (function (Object, magic) {
-          var set;
-
-          var checkArgs = function (O, proto) {
-            if (!ES.TypeIsObject(O)) {
-              throw new TypeError('cannot set prototype on a non-object');
-            }
-            if (!(proto === null || ES.TypeIsObject(proto))) {
-              throw new TypeError('can only set prototype to an object or null' + proto);
-            }
-          };
-
-          var setPrototypeOf = function (O, proto) {
-            checkArgs(O, proto);
-            set.call(O, proto);
-            return O;
-          };
-
-          try {
-            // this works already in Firefox and Safari
-            set = Object.getOwnPropertyDescriptor(Object.prototype, magic).set;
-            set.call({}, null);
-          } catch (e) {
-            if (Object.prototype !== {}[magic]) {
-              // IE < 11 cannot be shimmed
-              return;
-            }
-            // probably Chrome or some old Mobile stock browser
-            set = function (proto) {
-              this[magic] = proto;
-            };
-            // please note that this will **not** work
-            // in those browsers that do not inherit
-            // __proto__ by mistake from Object.prototype
-            // in these cases we should probably throw an error
-            // or at least be informed about the issue
-            setPrototypeOf.polyfill = setPrototypeOf(
-              setPrototypeOf({}, null),
-              Object.prototype
-            ) instanceof Object;
-            // setPrototypeOf.polyfill === true means it works as meant
-            // setPrototypeOf.polyfill === false means it's not 100% reliable
-            // setPrototypeOf.polyfill === undefined
-            // or
-            // setPrototypeOf.polyfill ==  null means it's not a polyfill
-            // which means it works as expected
-            // we can even delete Object.prototype.__proto__;
-          }
-          return setPrototypeOf;
-        })(Object, '__proto__')
-      });
-    }
-
-    // Workaround bug in Opera 12 where setPrototypeOf(x, null) doesn't work,
-    // but Object.create(null) does.
-    if (Object.setPrototypeOf && Object.getPrototypeOf &&
-        Object.getPrototypeOf(Object.setPrototypeOf({}, null)) !== null &&
-        Object.getPrototypeOf(Object.create(null)) === null) {
-      (function () {
-        var FAKENULL = Object.create(null);
-        var gpo = Object.getPrototypeOf, spo = Object.setPrototypeOf;
-        Object.getPrototypeOf = function (o) {
-          var result = gpo(o);
-          return result === FAKENULL ? null : result;
-        };
-        Object.setPrototypeOf = function (o, p) {
-          if (p === null) { p = FAKENULL; }
-          return spo(o, p);
-        };
-        Object.setPrototypeOf.polyfill = false;
-      })();
-    }
-
-    try {
-      Object.keys('foo');
-    } catch (e) {
-      var originalObjectKeys = Object.keys;
-      Object.keys = function (obj) {
-        return originalObjectKeys(ES.ToObject(obj));
-      };
-    }
-
-    var MathShims = {
-      acosh: function (value) {
-        value = Number(value);
-        if (Number.isNaN(value) || value < 1) return NaN;
-        if (value === 1) return 0;
-        if (value === Infinity) return value;
-        return Math.log(value + Math.sqrt(value * value - 1));
-      },
-
-      asinh: function (value) {
-        value = Number(value);
-        if (value === 0 || !global_isFinite(value)) {
-          return value;
-        }
-        return value < 0 ? -Math.asinh(-value) : Math.log(value + Math.sqrt(value * value + 1));
-      },
-
-      atanh: function (value) {
-        value = Number(value);
-        if (Number.isNaN(value) || value < -1 || value > 1) {
-          return NaN;
-        }
-        if (value === -1) return -Infinity;
-        if (value === 1) return Infinity;
-        if (value === 0) return value;
-        return 0.5 * Math.log((1 + value) / (1 - value));
-      },
-
-      cbrt: function (value) {
-        value = Number(value);
-        if (value === 0) return value;
-        var negate = value < 0, result;
-        if (negate) value = -value;
-        result = Math.pow(value, 1 / 3);
-        return negate ? -result : result;
-      },
-
-      clz32: function (value) {
-        // See https://bugs.ecmascript.org/show_bug.cgi?id=2465
-        value = Number(value);
-        var number = ES.ToUint32(value);
-        if (number === 0) {
-          return 32;
-        }
-        return 32 - (number).toString(2).length;
-      },
-
-      cosh: function (value) {
-        value = Number(value);
-        if (value === 0) return 1; // +0 or -0
-        if (Number.isNaN(value)) return NaN;
-        if (!global_isFinite(value)) return Infinity;
-        if (value < 0) value = -value;
-        if (value > 21) return Math.exp(value) / 2;
-        return (Math.exp(value) + Math.exp(-value)) / 2;
-      },
-
-      expm1: function (value) {
-        value = Number(value);
-        if (value === -Infinity) return -1;
-        if (!global_isFinite(value) || value === 0) return value;
-        return Math.exp(value) - 1;
-      },
-
-      hypot: function (x, y) {
-        var anyNaN = false;
-        var allZero = true;
-        var anyInfinity = false;
-        var numbers = [];
-        Array.prototype.every.call(arguments, function (arg) {
-          var num = Number(arg);
-          if (Number.isNaN(num)) {
-            anyNaN = true;
-          } else if (num === Infinity || num === -Infinity) {
-            anyInfinity = true;
-          } else if (num !== 0) {
-            allZero = false;
-          }
-          if (anyInfinity) {
-            return false;
-          } else if (!anyNaN) {
-            numbers.push(Math.abs(num));
-          }
-          return true;
-        });
-        if (anyInfinity) return Infinity;
-        if (anyNaN) return NaN;
-        if (allZero) return 0;
-
-        numbers.sort(function (a, b) { return b - a; });
-        var largest = numbers[0];
-        var divided = numbers.map(function (number) { return number / largest; });
-        var sum = divided.reduce(function (sum, number) { return sum += number * number; }, 0);
-        return largest * Math.sqrt(sum);
-      },
-
-      log2: function (value) {
-        return Math.log(value) * Math.LOG2E;
-      },
-
-      log10: function (value) {
-        return Math.log(value) * Math.LOG10E;
-      },
-
-      log1p: function (value) {
-        value = Number(value);
-        if (value < -1 || Number.isNaN(value)) return NaN;
-        if (value === 0 || value === Infinity) return value;
-        if (value === -1) return -Infinity;
-        var result = 0;
-        var n = 50;
-
-        if (value < 0 || value > 1) return Math.log(1 + value);
-        for (var i = 1; i < n; i++) {
-          if ((i % 2) === 0) {
-            result -= Math.pow(value, i) / i;
-          } else {
-            result += Math.pow(value, i) / i;
-          }
-        }
-
-        return result;
-      },
-
-      sign: function (value) {
-        var number = +value;
-        if (number === 0) return number;
-        if (Number.isNaN(number)) return number;
-        return number < 0 ? -1 : 1;
-      },
-
-      sinh: function (value) {
-        value = Number(value);
-        if (!global_isFinite(value) || value === 0) return value;
-        return (Math.exp(value) - Math.exp(-value)) / 2;
-      },
-
-      tanh: function (value) {
-        value = Number(value);
-        if (Number.isNaN(value) || value === 0) return value;
-        if (value === Infinity) return 1;
-        if (value === -Infinity) return -1;
-        return (Math.exp(value) - Math.exp(-value)) / (Math.exp(value) + Math.exp(-value));
-      },
-
-      trunc: function (value) {
-        var number = Number(value);
-        return number < 0 ? -Math.floor(-number) : Math.floor(number);
-      },
-
-      imul: function (x, y) {
-        // taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul
-        x = ES.ToUint32(x);
-        y = ES.ToUint32(y);
-        var ah  = (x >>> 16) & 0xffff;
-        var al = x & 0xffff;
-        var bh  = (y >>> 16) & 0xffff;
-        var bl = y & 0xffff;
-        // the shift by 0 fixes the sign on the high part
-        // the final |0 converts the unsigned value into a signed value
-        return ((al * bl) + (((ah * bl + al * bh) << 16) >>> 0)|0);
-      },
-
-      fround: function (x) {
-        if (x === 0 || x === Infinity || x === -Infinity || Number.isNaN(x)) {
-          return x;
-        }
-        var num = Number(x);
-        return numberConversion.toFloat32(num);
-      }
     };
-    defineProperties(Math, MathShims);
 
-    if (Math.imul(0xffffffff, 5) !== -5) {
-      // Safari 6.1, at least, reports "0" for this value
-      Math.imul = MathShims.imul;
-    }
-
-    // Promises
-    // Simplest possible implementation; use a 3rd-party library if you
-    // want the best possible speed and/or long stack traces.
-    var PromiseShim = (function () {
-
-      var Promise, Promise$prototype;
-
-      ES.IsPromise = function (promise) {
-        if (!ES.TypeIsObject(promise)) {
-          return false;
-        }
-        if (!promise._promiseConstructor) {
-          // _promiseConstructor is a bit more unique than _status, so we'll
-          // check that instead of the [[PromiseStatus]] internal field.
-          return false;
-        }
-        if (promise._status === undefined) {
-          return false; // uninitialized
-        }
-        return true;
-      };
-
-      // "PromiseCapability" in the spec is what most promise implementations
-      // call a "deferred".
-      var PromiseCapability = function (C) {
-        if (!ES.IsCallable(C)) {
-          throw new TypeError('bad promise constructor');
-        }
-        var capability = this;
-        var resolver = function (resolve, reject) {
-          capability.resolve = resolve;
-          capability.reject = reject;
-        };
-        capability.promise = ES.Construct(C, [resolver]);
-        // see https://bugs.ecmascript.org/show_bug.cgi?id=2478
-        if (!capability.promise._es6construct) {
-          throw new TypeError('bad promise constructor');
-        }
-        if (!(ES.IsCallable(capability.resolve) &&
-              ES.IsCallable(capability.reject))) {
-          throw new TypeError('bad promise constructor');
-        }
-      };
-
-      // find an appropriate setImmediate-alike
-      var setTimeout = globals.setTimeout;
-      var makeZeroTimeout;
-      if (typeof window !== 'undefined' && ES.IsCallable(window.postMessage)) {
-        makeZeroTimeout = function () {
-          // from http://dbaron.org/log/20100309-faster-timeouts
-          var timeouts = [];
-          var messageName = "zero-timeout-message";
-          var setZeroTimeout = function (fn) {
-            timeouts.push(fn);
-            window.postMessage(messageName, "*");
-          };
-          var handleMessage = function (event) {
-            if (event.source == window && event.data == messageName) {
-              event.stopPropagation();
-              if (timeouts.length === 0) { return; }
-              var fn = timeouts.shift();
-              fn();
-            }
-          };
-          window.addEventListener("message", handleMessage, true);
-          return setZeroTimeout;
-        };
+    var promiseReactionJob = function (handler, promiseCapability, argument) {
+      var handlerResult, f;
+      if (promiseCapability === PROMISE_FAKE_CAPABILITY) {
+        // Fast case, when we don't actually need to chain through to a
+        // (real) promiseCapability.
+        return handler(argument);
       }
-      var makePromiseAsap = function () {
-        // An efficient task-scheduler based on a pre-existing Promise
-        // implementation, which we can use even if we override the
-        // global Promise below (in order to workaround bugs)
-        // https://github.com/Raynos/observ-hash/issues/2#issuecomment-35857671
-        var P = globals.Promise;
-        return P && P.resolve && function (task) {
-          return P.resolve().then(task);
-        };
-      };
-      var enqueue = ES.IsCallable(globals.setImmediate) ?
-        globals.setImmediate.bind(globals) :
-        typeof process === 'object' && process.nextTick ? process.nextTick :
-        makePromiseAsap() ||
-        (ES.IsCallable(makeZeroTimeout) ? makeZeroTimeout() :
-        function (task) { setTimeout(task, 0); }); // fallback
+      try {
+        handlerResult = handler(argument);
+        f = promiseCapability.resolve;
+      } catch (e) {
+        handlerResult = e;
+        f = promiseCapability.reject;
+      }
+      f(handlerResult);
+    };
 
-      var triggerPromiseReactions = function (reactions, x) {
-        reactions.forEach(function (reaction) {
-          enqueue(function () {
-            // PromiseReactionTask
-            var handler = reaction.handler;
-            var capability = reaction.capability;
-            var resolve = capability.resolve;
-            var reject = capability.reject;
-            try {
-              var result = handler(x);
-              if (result === capability.promise) {
-                throw new TypeError('self resolution');
-              }
-              var updateResult =
-                updatePromiseFromPotentialThenable(result, capability);
-              if (!updateResult) {
-                resolve(result);
-              }
-            } catch (e) {
-              reject(e);
-            }
-          });
-        });
-      };
-
-      var updatePromiseFromPotentialThenable = function (x, capability) {
-        if (!ES.TypeIsObject(x)) {
-          return false;
+    var fulfillPromise = function (promise, value) {
+      var _promise = promise._promise;
+      var length = _promise.reactionLength;
+      if (length > 0) {
+        enqueuePromiseReactionJob(
+          _promise.fulfillReactionHandler0,
+          _promise.reactionCapability0,
+          value
+        );
+        _promise.fulfillReactionHandler0 = void 0;
+        _promise.rejectReactions0 = void 0;
+        _promise.reactionCapability0 = void 0;
+        if (length > 1) {
+          for (var i = 1, idx = 0; i < length; i++, idx += 3) {
+            enqueuePromiseReactionJob(
+              _promise[idx + PROMISE_FULFILL_OFFSET],
+              _promise[idx + PROMISE_CAPABILITY_OFFSET],
+              value
+            );
+            promise[idx + PROMISE_FULFILL_OFFSET] = void 0;
+            promise[idx + PROMISE_REJECT_OFFSET] = void 0;
+            promise[idx + PROMISE_CAPABILITY_OFFSET] = void 0;
+          }
         }
-        var resolve = capability.resolve;
-        var reject = capability.reject;
+      }
+      _promise.result = value;
+      _promise.state = PROMISE_FULFILLED;
+      _promise.reactionLength = 0;
+    };
+
+    var rejectPromise = function (promise, reason) {
+      var _promise = promise._promise;
+      var length = _promise.reactionLength;
+      if (length > 0) {
+        enqueuePromiseReactionJob(
+          _promise.rejectReactionHandler0,
+          _promise.reactionCapability0,
+          reason
+        );
+        _promise.fulfillReactionHandler0 = void 0;
+        _promise.rejectReactions0 = void 0;
+        _promise.reactionCapability0 = void 0;
+        if (length > 1) {
+          for (var i = 1, idx = 0; i < length; i++, idx += 3) {
+            enqueuePromiseReactionJob(
+              _promise[idx + PROMISE_REJECT_OFFSET],
+              _promise[idx + PROMISE_CAPABILITY_OFFSET],
+              reason
+            );
+            promise[idx + PROMISE_FULFILL_OFFSET] = void 0;
+            promise[idx + PROMISE_REJECT_OFFSET] = void 0;
+            promise[idx + PROMISE_CAPABILITY_OFFSET] = void 0;
+          }
+        }
+      }
+      _promise.result = reason;
+      _promise.state = PROMISE_REJECTED;
+      _promise.reactionLength = 0;
+    };
+
+    var createResolvingFunctions = function (promise) {
+      var alreadyResolved = false;
+      var resolve = function (resolution) {
+        var then;
+        if (alreadyResolved) { return; }
+        alreadyResolved = true;
+        if (resolution === promise) {
+          return rejectPromise(promise, new TypeError('Self resolution'));
+        }
+        if (!ES.TypeIsObject(resolution)) {
+          return fulfillPromise(promise, resolution);
+        }
         try {
-          var then = x.then; // only one invocation of accessor
-          if (!ES.IsCallable(then)) { return false; }
-          then.call(x, resolve, reject);
+          then = resolution.then;
         } catch (e) {
-          reject(e);
+          return rejectPromise(promise, e);
         }
-        return true;
-      };
-
-      var promiseResolutionHandler = function (promise, onFulfilled, onRejected) {
-        return function (x) {
-          if (x === promise) {
-            return onRejected(new TypeError('self resolution'));
-          }
-          var C = promise._promiseConstructor;
-          var capability = new PromiseCapability(C);
-          var updateResult = updatePromiseFromPotentialThenable(x, capability);
-          if (updateResult) {
-            return capability.promise.then(onFulfilled, onRejected);
-          } else {
-            return onFulfilled(x);
-          }
-        };
-      };
-
-      Promise = function (resolver) {
-        var promise = this;
-        promise = emulateES6construct(promise);
-        if (!promise._promiseConstructor) {
-          // we use _promiseConstructor as a stand-in for the internal
-          // [[PromiseStatus]] field; it's a little more unique.
-          throw new TypeError('bad promise');
+        if (!ES.IsCallable(then)) {
+          return fulfillPromise(promise, resolution);
         }
-        if (promise._status !== undefined) {
-          throw new TypeError('promise already initialized');
+        enqueue(function () {
+          promiseResolveThenableJob(promise, resolution, then);
+        });
+      };
+      var reject = function (reason) {
+        if (alreadyResolved) { return; }
+        alreadyResolved = true;
+        return rejectPromise(promise, reason);
+      };
+      return { resolve: resolve, reject: reject };
+    };
+
+    var optimizedThen = function (then, thenable, resolve, reject) {
+      // Optimization: since we discard the result, we can pass our
+      // own then implementation a special hint to let it know it
+      // doesn't have to create it.  (The PROMISE_FAKE_CAPABILITY
+      // object is local to this implementation and unforgeable outside.)
+      if (then === Promise$prototype$then) {
+        _call(then, thenable, resolve, reject, PROMISE_FAKE_CAPABILITY);
+      } else {
+        _call(then, thenable, resolve, reject);
+      }
+    };
+    var promiseResolveThenableJob = function (promise, thenable, then) {
+      var resolvingFunctions = createResolvingFunctions(promise);
+      var resolve = resolvingFunctions.resolve;
+      var reject = resolvingFunctions.reject;
+      try {
+        optimizedThen(then, thenable, resolve, reject);
+      } catch (e) {
+        reject(e);
+      }
+    };
+
+    var Promise$prototype, Promise$prototype$then;
+    var Promise = (function () {
+      var PromiseShim = function Promise(resolver) {
+        if (!(this instanceof PromiseShim)) {
+          throw new TypeError('Constructor Promise requires "new"');
+        }
+        if (this && this._promise) {
+          throw new TypeError('Bad construction');
         }
         // see https://bugs.ecmascript.org/show_bug.cgi?id=2482
         if (!ES.IsCallable(resolver)) {
           throw new TypeError('not a valid resolver');
         }
-        promise._status = 'unresolved';
-        promise._resolveReactions = [];
-        promise._rejectReactions = [];
-
-        var resolve = function (resolution) {
-          if (promise._status !== 'unresolved') { return; }
-          var reactions = promise._resolveReactions;
-          promise._result = resolution;
-          promise._resolveReactions = undefined;
-          promise._rejectReactions = undefined;
-          promise._status = 'has-resolution';
-          triggerPromiseReactions(reactions, resolution);
-        };
-        var reject = function (reason) {
-          if (promise._status !== 'unresolved') { return; }
-          var reactions = promise._rejectReactions;
-          promise._result = reason;
-          promise._resolveReactions = undefined;
-          promise._rejectReactions = undefined;
-          promise._status = 'has-rejection';
-          triggerPromiseReactions(reactions, reason);
-        };
+        var promise = emulateES6construct(this, PromiseShim, Promise$prototype, {
+          _promise: {
+            result: void 0,
+            state: PROMISE_PENDING,
+            // The first member of the "reactions" array is inlined here,
+            // since most promises only have one reaction.
+            // We've also exploded the 'reaction' object to inline the
+            // "handler" and "capability" fields, since both fulfill and
+            // reject reactions share the same capability.
+            reactionLength: 0,
+            fulfillReactionHandler0: void 0,
+            rejectReactionHandler0: void 0,
+            reactionCapability0: void 0
+          }
+        });
+        var resolvingFunctions = createResolvingFunctions(promise);
+        var reject = resolvingFunctions.reject;
         try {
-          resolver(resolve, reject);
+          resolver(resolvingFunctions.resolve, reject);
         } catch (e) {
           reject(e);
         }
         return promise;
       };
-      Promise$prototype = Promise.prototype;
-      defineProperties(Promise, {
-        '@@create': function (obj) {
-          var constructor = this;
-          // AllocatePromise
-          // The `obj` parameter is a hack we use for es5
-          // compatibility.
-          var prototype = constructor.prototype || Promise$prototype;
-          obj = obj || create(prototype);
-          defineProperties(obj, {
-            _status: undefined,
-            _result: undefined,
-            _resolveReactions: undefined,
-            _rejectReactions: undefined,
-            _promiseConstructor: undefined
-          });
-          obj._promiseConstructor = constructor;
-          return obj;
+      return PromiseShim;
+    }());
+    Promise$prototype = Promise.prototype;
+
+    var _promiseAllResolver = function (index, values, capability, remaining) {
+      var alreadyCalled = false;
+      return function (x) {
+        if (alreadyCalled) { return; }
+        alreadyCalled = true;
+        values[index] = x;
+        if ((--remaining.count) === 0) {
+          var resolve = capability.resolve;
+          resolve(values); // call w/ this===undefined
         }
-      });
-
-      var _promiseAllResolver = function (index, values, capability, remaining) {
-        var done = false;
-        return function (x) {
-          if (done) { return; } // protect against being called multiple times
-          done = true;
-          values[index] = x;
-          if ((--remaining.count) === 0) {
-            var resolve = capability.resolve;
-            resolve(values); // call w/ this===undefined
-          }
-        };
       };
+    };
 
-      Promise.all = function (iterable) {
-        var C = this;
-        var capability = new PromiseCapability(C);
-        var resolve = capability.resolve;
-        var reject = capability.reject;
+    var performPromiseAll = function (iteratorRecord, C, resultCapability) {
+      var it = iteratorRecord.iterator;
+      var values = [];
+      var remaining = { count: 1 };
+      var next, nextValue;
+      var index = 0;
+      while (true) {
         try {
-          if (!ES.IsIterable(iterable)) {
-            throw new TypeError('bad iterable');
+          next = ES.IteratorStep(it);
+          if (next === false) {
+            iteratorRecord.done = true;
+            break;
           }
-          var it = ES.GetIterator(iterable);
-          var values = [], remaining = { count: 1 };
-          for (var index = 0; ; index++) {
-            var next = ES.IteratorNext(it);
-            if (next.done) {
-              break;
-            }
-            var nextPromise = C.resolve(next.value);
-            var resolveElement = _promiseAllResolver(
-              index, values, capability, remaining
-            );
-            remaining.count++;
-            nextPromise.then(resolveElement, capability.reject);
-          }
-          if ((--remaining.count) === 0) {
-            resolve(values); // call w/ this===undefined
-          }
+          nextValue = next.value;
         } catch (e) {
-          reject(e);
+          iteratorRecord.done = true;
+          throw e;
         }
-        return capability.promise;
-      };
+        values[index] = void 0;
+        var nextPromise = C.resolve(nextValue);
+        var resolveElement = _promiseAllResolver(
+          index, values, resultCapability, remaining
+        );
+        remaining.count += 1;
+        optimizedThen(nextPromise.then, nextPromise, resolveElement, resultCapability.reject);
+        index += 1;
+      }
+      if ((--remaining.count) === 0) {
+        var resolve = resultCapability.resolve;
+        resolve(values); // call w/ this===undefined
+      }
+      return resultCapability.promise;
+    };
 
-      Promise.race = function (iterable) {
-        var C = this;
-        var capability = new PromiseCapability(C);
-        var resolve = capability.resolve;
-        var reject = capability.reject;
+    var performPromiseRace = function (iteratorRecord, C, resultCapability) {
+      var it = iteratorRecord.iterator;
+      var next, nextValue, nextPromise;
+      while (true) {
         try {
-          if (!ES.IsIterable(iterable)) {
-            throw new TypeError('bad iterable');
+          next = ES.IteratorStep(it);
+          if (next === false) {
+            // NOTE: If iterable has no items, resulting promise will never
+            // resolve; see:
+            // https://github.com/domenic/promises-unwrapping/issues/75
+            // https://bugs.ecmascript.org/show_bug.cgi?id=2515
+            iteratorRecord.done = true;
+            break;
           }
-          var it = ES.GetIterator(iterable);
-          while (true) {
-            var next = ES.IteratorNext(it);
-            if (next.done) {
-              // If iterable has no items, resulting promise will never
-              // resolve; see:
-              // https://github.com/domenic/promises-unwrapping/issues/75
-              // https://bugs.ecmascript.org/show_bug.cgi?id=2515
-              break;
-            }
-            var nextPromise = C.resolve(next.value);
-            nextPromise.then(resolve, reject);
-          }
+          nextValue = next.value;
         } catch (e) {
-          reject(e);
+          iteratorRecord.done = true;
+          throw e;
         }
-        return capability.promise;
-      };
+        nextPromise = C.resolve(nextValue);
+        optimizedThen(nextPromise.then, nextPromise, resultCapability.resolve, resultCapability.reject);
+      }
+      return resultCapability.promise;
+    };
 
-      Promise.reject = function (reason) {
+    defineProperties(Promise, {
+      all: function all(iterable) {
         var C = this;
+        if (!ES.TypeIsObject(C)) {
+          throw new TypeError('Promise is not object');
+        }
         var capability = new PromiseCapability(C);
-        var reject = capability.reject;
-        reject(reason); // call with this===undefined
-        return capability.promise;
-      };
+        var iterator, iteratorRecord;
+        try {
+          iterator = ES.GetIterator(iterable);
+          iteratorRecord = { iterator: iterator, done: false };
+          return performPromiseAll(iteratorRecord, C, capability);
+        } catch (e) {
+          var exception = e;
+          if (iteratorRecord && !iteratorRecord.done) {
+            try {
+              ES.IteratorClose(iterator, true);
+            } catch (ee) {
+              exception = ee;
+            }
+          }
+          var reject = capability.reject;
+          reject(exception);
+          return capability.promise;
+        }
+      },
 
-      Promise.resolve = function (v) {
+      race: function race(iterable) {
         var C = this;
+        if (!ES.TypeIsObject(C)) {
+          throw new TypeError('Promise is not object');
+        }
+        var capability = new PromiseCapability(C);
+        var iterator, iteratorRecord;
+        try {
+          iterator = ES.GetIterator(iterable);
+          iteratorRecord = { iterator: iterator, done: false };
+          return performPromiseRace(iteratorRecord, C, capability);
+        } catch (e) {
+          var exception = e;
+          if (iteratorRecord && !iteratorRecord.done) {
+            try {
+              ES.IteratorClose(iterator, true);
+            } catch (ee) {
+              exception = ee;
+            }
+          }
+          var reject = capability.reject;
+          reject(exception);
+          return capability.promise;
+        }
+      },
+
+      reject: function reject(reason) {
+        var C = this;
+        if (!ES.TypeIsObject(C)) {
+          throw new TypeError('Bad promise constructor');
+        }
+        var capability = new PromiseCapability(C);
+        var rejectFunc = capability.reject;
+        rejectFunc(reason); // call with this===undefined
+        return capability.promise;
+      },
+
+      resolve: function resolve(v) {
+        // See https://esdiscuss.org/topic/fixing-promise-resolve for spec
+        var C = this;
+        if (!ES.TypeIsObject(C)) {
+          throw new TypeError('Bad promise constructor');
+        }
         if (ES.IsPromise(v)) {
-          var constructor = v._promiseConstructor;
-          if (constructor === C) { return v; }
+          var constructor = v.constructor;
+          if (constructor === C) {
+            return v;
+          }
         }
         var capability = new PromiseCapability(C);
-        var resolve = capability.resolve;
-        resolve(v); // call with this===undefined
+        var resolveFunc = capability.resolve;
+        resolveFunc(v); // call with this===undefined
         return capability.promise;
-      };
+      }
+    });
 
-      Promise.prototype['catch'] = function (onRejected) {
-        return this.then(undefined, onRejected);
-      };
+    defineProperties(Promise$prototype, {
+      'catch': function (onRejected) {
+        return this.then(null, onRejected);
+      },
 
-      Promise.prototype.then = function (onFulfilled, onRejected) {
+      then: function then(onFulfilled, onRejected) {
         var promise = this;
         if (!ES.IsPromise(promise)) { throw new TypeError('not a promise'); }
-        // this.constructor not this._promiseConstructor; see
-        // https://bugs.ecmascript.org/show_bug.cgi?id=2513
-        var C = this.constructor;
-        var capability = new PromiseCapability(C);
-        if (!ES.IsCallable(onRejected)) {
-          onRejected = function (e) { throw e; };
+        var C = ES.SpeciesConstructor(promise, Promise);
+        var resultCapability;
+        var returnValueIsIgnored = arguments.length > 2 && arguments[2] === PROMISE_FAKE_CAPABILITY;
+        if (returnValueIsIgnored && C === Promise) {
+          resultCapability = PROMISE_FAKE_CAPABILITY;
+        } else {
+          resultCapability = new PromiseCapability(C);
         }
-        if (!ES.IsCallable(onFulfilled)) {
-          onFulfilled = function (x) { return x; };
+        // PerformPromiseThen(promise, onFulfilled, onRejected, resultCapability)
+        // Note that we've split the 'reaction' object into its two
+        // components, "capabilities" and "handler"
+        // "capabilities" is always equal to `resultCapability`
+        var fulfillReactionHandler = ES.IsCallable(onFulfilled) ? onFulfilled : PROMISE_IDENTITY;
+        var rejectReactionHandler = ES.IsCallable(onRejected) ? onRejected : PROMISE_THROWER;
+        var _promise = promise._promise;
+        var value;
+        if (_promise.state === PROMISE_PENDING) {
+          if (_promise.reactionLength === 0) {
+            _promise.fulfillReactionHandler0 = fulfillReactionHandler;
+            _promise.rejectReactionHandler0 = rejectReactionHandler;
+            _promise.reactionCapability0 = resultCapability;
+          } else {
+            var idx = 3 * (_promise.reactionLength - 1);
+            _promise[idx + PROMISE_FULFILL_OFFSET] = fulfillReactionHandler;
+            _promise[idx + PROMISE_REJECT_OFFSET] = rejectReactionHandler;
+            _promise[idx + PROMISE_CAPABILITY_OFFSET] = resultCapability;
+          }
+          _promise.reactionLength += 1;
+        } else if (_promise.state === PROMISE_FULFILLED) {
+          value = _promise.result;
+          enqueuePromiseReactionJob(
+            fulfillReactionHandler, resultCapability, value
+          );
+        } else if (_promise.state === PROMISE_REJECTED) {
+          value = _promise.result;
+          enqueuePromiseReactionJob(
+            rejectReactionHandler, resultCapability, value
+          );
+        } else {
+          throw new TypeError('unexpected Promise state');
         }
-        var resolutionHandler =
-          promiseResolutionHandler(promise, onFulfilled, onRejected);
-        var resolveReaction =
-          { capability: capability, handler: resolutionHandler };
-        var rejectReaction =
-          { capability: capability, handler: onRejected };
-        switch (promise._status) {
-        case 'unresolved':
-          promise._resolveReactions.push(resolveReaction);
-          promise._rejectReactions.push(rejectReaction);
-          break;
-        case 'has-resolution':
-          triggerPromiseReactions([resolveReaction], promise._result);
-          break;
-        case 'has-rejection':
-          triggerPromiseReactions([rejectReaction], promise._result);
-          break;
-        default:
-          throw new TypeError('unexpected');
-        }
-        return capability.promise;
-      };
+        return resultCapability.promise;
+      }
+    });
+    // This helps the optimizer by ensuring that methods which take
+    // capabilities aren't polymorphic.
+    PROMISE_FAKE_CAPABILITY = new PromiseCapability(Promise);
+    Promise$prototype$then = Promise$prototype.then;
 
-      return Promise;
-    })();
+    return Promise;
+  }());
+
+  // Chrome's native Promise has extra methods that it shouldn't have. Let's remove them.
+  if (globals.Promise) {
+    delete globals.Promise.accept;
+    delete globals.Promise.defer;
+    delete globals.Promise.prototype.chain;
+  }
+
+  if (typeof PromiseShim === 'function') {
     // export the Promise constructor.
     defineProperties(globals, { Promise: PromiseShim });
     // In Chrome 33 (and thereabouts) Promise is defined, but the
     // implementation is buggy in a number of ways.  Let's check subclassing
     // support to see if we have a buggy implementation.
     var promiseSupportsSubclassing = supportsSubclassing(globals.Promise, function (S) {
-      return S.resolve(42) instanceof S;
+      return S.resolve(42).then(function () {}) instanceof S;
     });
-    var promiseIgnoresNonFunctionThenCallbacks = (function () {
+    var promiseIgnoresNonFunctionThenCallbacks = !throwsError(function () { globals.Promise.reject(42).then(null, 5).then(null, noop); });
+    var promiseRequiresObjectContext = throwsError(function () { globals.Promise.call(3, noop); });
+    // Promise.resolve() was errata'ed late in the ES6 process.
+    // See: https://bugzilla.mozilla.org/show_bug.cgi?id=1170742
+    //      https://code.google.com/p/v8/issues/detail?id=4161
+    // It serves as a proxy for a number of other bugs in early Promise
+    // implementations.
+    var promiseResolveBroken = (function (Promise) {
+      var p = Promise.resolve(5);
+      p.constructor = {};
+      var p2 = Promise.resolve(p);
       try {
-        globals.Promise.reject(42).then(null, 5).then(null, function () {});
-        return true;
-      } catch (ex) {
-        return false;
+        p2.then(null, noop).then(null, noop); // avoid "uncaught rejection" warnings in console
+      } catch (e) {
+        return true; // v8 native Promises break here https://code.google.com/p/chromium/issues/detail?id=575314
       }
-    }());
-    var promiseRequiresObjectContext = (function () {
-      try { Promise.call(3, function () {}); } catch (e) { return true; }
-      return false;
-    }());
-    if (!promiseSupportsSubclassing || !promiseIgnoresNonFunctionThenCallbacks || !promiseRequiresObjectContext) {
-      globals.Promise = PromiseShim;
-    }
+      return p === p2; // This *should* be false!
+    }(globals.Promise));
 
-    // Map and Set require a true ES5 environment
-    // Their fast path also requires that the environment preserve
-    // property insertion order, which is not guaranteed by the spec.
-    var testOrder = function(a) {
-      var b = Object.keys(a.reduce(function (o, k) {
-        o[k] = true;
-        return o;
-      }, {}));
-      return a.join(':') === b.join(':');
+    // Chrome 46 (probably older too) does not retrieve a thenable's .then synchronously
+    var getsThenSynchronously = supportsDescriptors && (function () {
+      var count = 0;
+      var thenable = Object.defineProperty({}, 'then', { get: function () { count += 1; } });
+      Promise.resolve(thenable);
+      return count === 1;
+    }());
+
+    var BadResolverPromise = function BadResolverPromise(executor) {
+      var p = new Promise(executor);
+      executor(3, function () {});
+      this.then = p.then;
+      this.constructor = BadResolverPromise;
     };
-    var preservesInsertionOrder = testOrder(['z', 'a', 'bb']);
-    // some engines (eg, Chrome) only preserve insertion order for string keys
-    var preservesNumericInsertionOrder = testOrder(['z', 1, 'a', '3', 2]);
+    BadResolverPromise.prototype = Promise.prototype;
+    BadResolverPromise.all = Promise.all;
+    // Chrome Canary 49 (probably older too) has some implementation bugs
+    var hasBadResolverPromise = valueOrFalseIfThrows(function () {
+      return !!BadResolverPromise.all([1, 2]);
+    });
 
-    if (supportsDescriptors) {
+    if (!promiseSupportsSubclassing || !promiseIgnoresNonFunctionThenCallbacks ||
+        !promiseRequiresObjectContext || promiseResolveBroken ||
+        !getsThenSynchronously || hasBadResolverPromise) {
+      /* globals Promise: true */
+      /* eslint-disable no-undef */
+      /* jshint -W020 */
+      Promise = PromiseShim;
+      /* jshint +W020 */
+      /* eslint-enable no-undef */
+      /* globals Promise: false */
+      overrideNative(globals, 'Promise', PromiseShim);
+    }
+    if (Promise.all.length !== 1) {
+      var origAll = Promise.all;
+      overrideNative(Promise, 'all', function all(iterable) {
+        return ES.Call(origAll, this, arguments);
+      });
+    }
+    if (Promise.race.length !== 1) {
+      var origRace = Promise.race;
+      overrideNative(Promise, 'race', function race(iterable) {
+        return ES.Call(origRace, this, arguments);
+      });
+    }
+    if (Promise.resolve.length !== 1) {
+      var origResolve = Promise.resolve;
+      overrideNative(Promise, 'resolve', function resolve(x) {
+        return ES.Call(origResolve, this, arguments);
+      });
+    }
+    if (Promise.reject.length !== 1) {
+      var origReject = Promise.reject;
+      overrideNative(Promise, 'reject', function reject(r) {
+        return ES.Call(origReject, this, arguments);
+      });
+    }
+    ensureEnumerable(Promise, 'all');
+    ensureEnumerable(Promise, 'race');
+    ensureEnumerable(Promise, 'resolve');
+    ensureEnumerable(Promise, 'reject');
+    addDefaultSpecies(Promise);
+  }
 
-      var fastkey = function fastkey(key) {
-        if (!preservesInsertionOrder) {
-          return null;
-        }
-        var type = typeof key;
-        if (type === 'string') {
-          return '$' + key;
-        } else if (type === 'number') {
-          // note that -0 will get coerced to "0" when used as a property key
-          if (!preservesNumericInsertionOrder) {
-            return 'n' + key;
-          }
-          return key;
-        }
+  // Map and Set require a true ES5 environment
+  // Their fast path also requires that the environment preserve
+  // property insertion order, which is not guaranteed by the spec.
+  var testOrder = function (a) {
+    var b = keys(_reduce(a, function (o, k) {
+      o[k] = true;
+      return o;
+    }, {}));
+    return a.join(':') === b.join(':');
+  };
+  var preservesInsertionOrder = testOrder(['z', 'a', 'bb']);
+  // some engines (eg, Chrome) only preserve insertion order for string keys
+  var preservesNumericInsertionOrder = testOrder(['z', 1, 'a', '3', 2]);
+
+  if (supportsDescriptors) {
+
+    var fastkey = function fastkey(key) {
+      if (!preservesInsertionOrder) {
         return null;
-      };
+      }
+      if (typeof key === 'undefined' || key === null) {
+        return '^' + ES.ToString(key);
+      } else if (typeof key === 'string') {
+        return '$' + key;
+      } else if (typeof key === 'number') {
+        // note that -0 will get coerced to "0" when used as a property key
+        if (!preservesNumericInsertionOrder) {
+          return 'n' + key;
+        }
+        return key;
+      } else if (typeof key === 'boolean') {
+        return 'b' + key;
+      }
+      return null;
+    };
 
-      var emptyObject = function emptyObject() {
-        // accomodate some older not-quite-ES5 browsers
-        return Object.create ? Object.create(null) : {};
-      };
+    var emptyObject = function emptyObject() {
+      // accomodate some older not-quite-ES5 browsers
+      return Object.create ? Object.create(null) : {};
+    };
 
-      var collectionShims = {
-        Map: (function () {
-
-          var empty = {};
-
-          function MapEntry(key, value) {
-            this.key = key;
-            this.value = value;
-            this.next = null;
-            this.prev = null;
+    var addIterableToMap = function addIterableToMap(MapConstructor, map, iterable) {
+      if (isArray(iterable) || Type.string(iterable)) {
+        _forEach(iterable, function (entry) {
+          if (!ES.TypeIsObject(entry)) {
+            throw new TypeError('Iterator value ' + entry + ' is not an entry object');
           }
-
-          MapEntry.prototype.isRemoved = function () {
-            return this.key === empty;
-          };
-
-          function MapIterator(map, kind) {
-            this.head = map._head;
-            this.i = this.head;
-            this.kind = kind;
+          map.set(entry[0], entry[1]);
+        });
+      } else if (iterable instanceof MapConstructor) {
+        _call(MapConstructor.prototype.forEach, iterable, function (value, key) {
+          map.set(key, value);
+        });
+      } else {
+        var iter, adder;
+        if (iterable !== null && typeof iterable !== 'undefined') {
+          adder = map.set;
+          if (!ES.IsCallable(adder)) { throw new TypeError('bad map'); }
+          iter = ES.GetIterator(iterable);
+        }
+        if (typeof iter !== 'undefined') {
+          while (true) {
+            var next = ES.IteratorStep(iter);
+            if (next === false) { break; }
+            var nextItem = next.value;
+            try {
+              if (!ES.TypeIsObject(nextItem)) {
+                throw new TypeError('Iterator value ' + nextItem + ' is not an entry object');
+              }
+              _call(adder, map, nextItem[0], nextItem[1]);
+            } catch (e) {
+              ES.IteratorClose(iter, true);
+              throw e;
+            }
           }
-
-          MapIterator.prototype = {
-            next: function () {
-              var i = this.i, kind = this.kind, head = this.head, result;
-              if (this.i === undefined) {
-                return { value: undefined, done: true };
-              }
-              while (i.isRemoved() && i !== head) {
-                // back up off of removed entries
-                i = i.prev;
-              }
-              // advance to next unreturned element.
-              while (i.next !== head) {
-                i = i.next;
-                if (!i.isRemoved()) {
-                  if (kind === "key") {
-                    result = i.key;
-                  } else if (kind === "value") {
-                    result = i.value;
-                  } else {
-                    result = [i.key, i.value];
-                  }
-                  this.i = i;
-                  return { value: result, done: false };
-                }
-              }
-              // once the iterator is done, it is done forever.
-              this.i = undefined;
-              return { value: undefined, done: true };
+        }
+      }
+    };
+    var addIterableToSet = function addIterableToSet(SetConstructor, set, iterable) {
+      if (isArray(iterable) || Type.string(iterable)) {
+        _forEach(iterable, function (value) {
+          set.add(value);
+        });
+      } else if (iterable instanceof SetConstructor) {
+        _call(SetConstructor.prototype.forEach, iterable, function (value) {
+          set.add(value);
+        });
+      } else {
+        var iter, adder;
+        if (iterable !== null && typeof iterable !== 'undefined') {
+          adder = set.add;
+          if (!ES.IsCallable(adder)) { throw new TypeError('bad set'); }
+          iter = ES.GetIterator(iterable);
+        }
+        if (typeof iter !== 'undefined') {
+          while (true) {
+            var next = ES.IteratorStep(iter);
+            if (next === false) { break; }
+            var nextValue = next.value;
+            try {
+              _call(adder, set, nextValue);
+            } catch (e) {
+              ES.IteratorClose(iter, true);
+              throw e;
             }
-          };
-          addIterator(MapIterator.prototype);
-
-          function Map(iterable) {
-            var map = this;
-            map = emulateES6construct(map);
-            if (!map._es6map) {
-              throw new TypeError('bad map');
-            }
-
-            var head = new MapEntry(null, null);
-            // circular doubly-linked list.
-            head.next = head.prev = head;
-
-            defineProperties(map, {
-              _head: head,
-              _storage: emptyObject(),
-              _size: 0
-            });
-
-            // Optionally initialize map from iterable
-            if (iterable !== undefined && iterable !== null) {
-              var it = ES.GetIterator(iterable);
-              var adder = map.set;
-              if (!ES.IsCallable(adder)) { throw new TypeError('bad map'); }
-              while (true) {
-                var next = ES.IteratorNext(it);
-                if (next.done) { break; }
-                var nextItem = next.value;
-                if (!ES.TypeIsObject(nextItem)) {
-                  throw new TypeError('expected iterable of pairs');
-                }
-                adder.call(map, nextItem[0], nextItem[1]);
-              }
-            }
-            return map;
           }
-          var Map$prototype = Map.prototype;
-          defineProperties(Map, {
-            '@@create': function (obj) {
-              var constructor = this;
-              var prototype = constructor.prototype || Map$prototype;
-              obj = obj || create(prototype);
-              defineProperties(obj, { _es6map: true });
-              return obj;
+        }
+      }
+    };
+
+    var collectionShims = {
+      Map: (function () {
+
+        var empty = {};
+
+        var MapEntry = function MapEntry(key, value) {
+          this.key = key;
+          this.value = value;
+          this.next = null;
+          this.prev = null;
+        };
+
+        MapEntry.prototype.isRemoved = function isRemoved() {
+          return this.key === empty;
+        };
+
+        var isMap = function isMap(map) {
+          return !!map._es6map;
+        };
+
+        var requireMapSlot = function requireMapSlot(map, method) {
+          if (!ES.TypeIsObject(map) || !isMap(map)) {
+            throw new TypeError('Method Map.prototype.' + method + ' called on incompatible receiver ' + ES.ToString(map));
+          }
+        };
+
+        var MapIterator = function MapIterator(map, kind) {
+          requireMapSlot(map, '[[MapIterator]]');
+          this.head = map._head;
+          this.i = this.head;
+          this.kind = kind;
+        };
+
+        MapIterator.prototype = {
+          next: function next() {
+            var i = this.i;
+            var kind = this.kind;
+            var head = this.head;
+            if (typeof this.i === 'undefined') {
+              return iteratorResult();
             }
-          });
-
-          Object.defineProperty(Map.prototype, 'size', {
-            configurable: true,
-            enumerable: false,
-            get: function () {
-              if (typeof this._size === 'undefined') {
-                throw new TypeError('size method called on incompatible Map');
-              }
-              return this._size;
+            while (i.isRemoved() && i !== head) {
+              // back up off of removed entries
+              i = i.prev;
             }
-          });
-
-          defineProperties(Map.prototype, {
-            get: function (key) {
-              var fkey = fastkey(key);
-              if (fkey !== null) {
-                // fast O(1) path
-                var entry = this._storage[fkey];
-                return entry ? entry.value : undefined;
-              }
-              var head = this._head, i = head;
-              while ((i = i.next) !== head) {
-                if (ES.SameValueZero(i.key, key)) {
-                  return i.value;
-                }
-              }
-              return undefined;
-            },
-
-            has: function (key) {
-              var fkey = fastkey(key);
-              if (fkey !== null) {
-                // fast O(1) path
-                return typeof this._storage[fkey] !== 'undefined';
-              }
-              var head = this._head, i = head;
-              while ((i = i.next) !== head) {
-                if (ES.SameValueZero(i.key, key)) {
-                  return true;
-                }
-              }
-              return false;
-            },
-
-            set: function (key, value) {
-              var head = this._head, i = head, entry;
-              var fkey = fastkey(key);
-              if (fkey !== null) {
-                // fast O(1) path
-                if (typeof this._storage[fkey] !== 'undefined') {
-                  this._storage[fkey].value = value;
-                  return;
+            // advance to next unreturned element.
+            var result;
+            while (i.next !== head) {
+              i = i.next;
+              if (!i.isRemoved()) {
+                if (kind === 'key') {
+                  result = i.key;
+                } else if (kind === 'value') {
+                  result = i.value;
                 } else {
-                  entry = this._storage[fkey] = new MapEntry(key, value);
-                  i = head.prev;
-                  // fall through
+                  result = [i.key, i.value];
                 }
+                this.i = i;
+                return iteratorResult(result);
               }
-              while ((i = i.next) !== head) {
-                if (ES.SameValueZero(i.key, key)) {
-                  i.value = value;
-                  return;
-                }
-              }
-              entry = entry || new MapEntry(key, value);
-              if (ES.SameValue(-0, key)) {
-                entry.key = +0; // coerce -0 to +0 in entry
-              }
-              entry.next = this._head;
-              entry.prev = this._head.prev;
-              entry.prev.next = entry;
-              entry.next.prev = entry;
-              this._size += 1;
-            },
+            }
+            // once the iterator is done, it is done forever.
+            this.i = void 0;
+            return iteratorResult();
+          }
+        };
+        addIterator(MapIterator.prototype);
 
-            'delete': function (key) {
-              var head = this._head, i = head;
-              var fkey = fastkey(key);
-              if (fkey !== null) {
-                // fast O(1) path
-                if (typeof this._storage[fkey] === 'undefined') {
-                  return false;
-                }
-                i = this._storage[fkey].prev;
-                delete this._storage[fkey];
+        var Map$prototype;
+        var MapShim = function Map() {
+          if (!(this instanceof Map)) {
+            throw new TypeError('Constructor Map requires "new"');
+          }
+          if (this && this._es6map) {
+            throw new TypeError('Bad construction');
+          }
+          var map = emulateES6construct(this, Map, Map$prototype, {
+            _es6map: true,
+            _head: null,
+            _storage: emptyObject(),
+            _size: 0
+          });
+
+          var head = new MapEntry(null, null);
+          // circular doubly-linked list.
+          head.next = head.prev = head;
+          map._head = head;
+
+          // Optionally initialize map from iterable
+          if (arguments.length > 0) {
+            addIterableToMap(Map, map, arguments[0]);
+          }
+          return map;
+        };
+        Map$prototype = MapShim.prototype;
+
+        Value.getter(Map$prototype, 'size', function () {
+          if (typeof this._size === 'undefined') {
+            throw new TypeError('size method called on incompatible Map');
+          }
+          return this._size;
+        });
+
+        defineProperties(Map$prototype, {
+          get: function get(key) {
+            requireMapSlot(this, 'get');
+            var fkey = fastkey(key);
+            if (fkey !== null) {
+              // fast O(1) path
+              var entry = this._storage[fkey];
+              if (entry) {
+                return entry.value;
+              } else {
+                return;
+              }
+            }
+            var head = this._head;
+            var i = head;
+            while ((i = i.next) !== head) {
+              if (ES.SameValueZero(i.key, key)) {
+                return i.value;
+              }
+            }
+          },
+
+          has: function has(key) {
+            requireMapSlot(this, 'has');
+            var fkey = fastkey(key);
+            if (fkey !== null) {
+              // fast O(1) path
+              return typeof this._storage[fkey] !== 'undefined';
+            }
+            var head = this._head;
+            var i = head;
+            while ((i = i.next) !== head) {
+              if (ES.SameValueZero(i.key, key)) {
+                return true;
+              }
+            }
+            return false;
+          },
+
+          set: function set(key, value) {
+            requireMapSlot(this, 'set');
+            var head = this._head;
+            var i = head;
+            var entry;
+            var fkey = fastkey(key);
+            if (fkey !== null) {
+              // fast O(1) path
+              if (typeof this._storage[fkey] !== 'undefined') {
+                this._storage[fkey].value = value;
+                return this;
+              } else {
+                entry = this._storage[fkey] = new MapEntry(key, value);
+                i = head.prev;
                 // fall through
               }
-              while ((i = i.next) !== head) {
-                if (ES.SameValueZero(i.key, key)) {
-                  i.key = i.value = empty;
-                  i.prev.next = i.next;
-                  i.next.prev = i.prev;
-                  this._size -= 1;
-                  return true;
-                }
+            }
+            while ((i = i.next) !== head) {
+              if (ES.SameValueZero(i.key, key)) {
+                i.value = value;
+                return this;
               }
-              return false;
-            },
+            }
+            entry = entry || new MapEntry(key, value);
+            if (ES.SameValue(-0, key)) {
+              entry.key = +0; // coerce -0 to +0 in entry
+            }
+            entry.next = this._head;
+            entry.prev = this._head.prev;
+            entry.prev.next = entry;
+            entry.next.prev = entry;
+            this._size += 1;
+            return this;
+          },
 
-            clear: function () {
-              this._size = 0;
-              this._storage = emptyObject();
-              var head = this._head, i = head, p = i.next;
-              while ((i = p) !== head) {
+          'delete': function (key) {
+            requireMapSlot(this, 'delete');
+            var head = this._head;
+            var i = head;
+            var fkey = fastkey(key);
+            if (fkey !== null) {
+              // fast O(1) path
+              if (typeof this._storage[fkey] === 'undefined') {
+                return false;
+              }
+              i = this._storage[fkey].prev;
+              delete this._storage[fkey];
+              // fall through
+            }
+            while ((i = i.next) !== head) {
+              if (ES.SameValueZero(i.key, key)) {
                 i.key = i.value = empty;
-                p = i.next;
-                i.next = i.prev = head;
-              }
-              head.next = head.prev = head;
-            },
-
-            keys: function () {
-              return new MapIterator(this, "key");
-            },
-
-            values: function () {
-              return new MapIterator(this, "value");
-            },
-
-            entries: function () {
-              return new MapIterator(this, "key+value");
-            },
-
-            forEach: function (callback) {
-              var context = arguments.length > 1 ? arguments[1] : null;
-              var it = this.entries();
-              for (var entry = it.next(); !entry.done; entry = it.next()) {
-                callback.call(context, entry.value[1], entry.value[0], this);
+                i.prev.next = i.next;
+                i.next.prev = i.prev;
+                this._size -= 1;
+                return true;
               }
             }
+            return false;
+          },
+
+          clear: function clear() {
+            requireMapSlot(this, 'clear');
+            this._size = 0;
+            this._storage = emptyObject();
+            var head = this._head;
+            var i = head;
+            var p = i.next;
+            while ((i = p) !== head) {
+              i.key = i.value = empty;
+              p = i.next;
+              i.next = i.prev = head;
+            }
+            head.next = head.prev = head;
+          },
+
+          keys: function keys() {
+            requireMapSlot(this, 'keys');
+            return new MapIterator(this, 'key');
+          },
+
+          values: function values() {
+            requireMapSlot(this, 'values');
+            return new MapIterator(this, 'value');
+          },
+
+          entries: function entries() {
+            requireMapSlot(this, 'entries');
+            return new MapIterator(this, 'key+value');
+          },
+
+          forEach: function forEach(callback) {
+            requireMapSlot(this, 'forEach');
+            var context = arguments.length > 1 ? arguments[1] : null;
+            var it = this.entries();
+            for (var entry = it.next(); !entry.done; entry = it.next()) {
+              if (context) {
+                _call(callback, context, entry.value[1], entry.value[0], this);
+              } else {
+                callback(entry.value[1], entry.value[0], this);
+              }
+            }
+          }
+        });
+        addIterator(Map$prototype, Map$prototype.entries);
+
+        return MapShim;
+      }()),
+
+      Set: (function () {
+        var isSet = function isSet(set) {
+          return set._es6set && typeof set._storage !== 'undefined';
+        };
+        var requireSetSlot = function requireSetSlot(set, method) {
+          if (!ES.TypeIsObject(set) || !isSet(set)) {
+            // https://github.com/paulmillr/es6-shim/issues/176
+            throw new TypeError('Set.prototype.' + method + ' called on incompatible receiver ' + ES.ToString(set));
+          }
+        };
+
+        // Creating a Map is expensive.  To speed up the common case of
+        // Sets containing only string or numeric keys, we use an object
+        // as backing storage and lazily create a full Map only when
+        // required.
+        var Set$prototype;
+        var SetShim = function Set() {
+          if (!(this instanceof Set)) {
+            throw new TypeError('Constructor Set requires "new"');
+          }
+          if (this && this._es6set) {
+            throw new TypeError('Bad construction');
+          }
+          var set = emulateES6construct(this, Set, Set$prototype, {
+            _es6set: true,
+            '[[SetData]]': null,
+            _storage: emptyObject()
           });
-          addIterator(Map.prototype, function () { return this.entries(); });
+          if (!set._es6set) {
+            throw new TypeError('bad set');
+          }
 
-          return Map;
-        })(),
+          // Optionally initialize Set from iterable
+          if (arguments.length > 0) {
+            addIterableToSet(Set, set, arguments[0]);
+          }
+          return set;
+        };
+        Set$prototype = SetShim.prototype;
 
-        Set: (function () {
-          // Creating a Map is expensive.  To speed up the common case of
-          // Sets containing only string or numeric keys, we use an object
-          // as backing storage and lazily create a full Map only when
-          // required.
-          var SetShim = function Set(iterable) {
-            var set = this;
-            set = emulateES6construct(set);
-            if (!set._es6set) {
-              throw new TypeError('bad set');
+        var decodeKey = function (key) {
+          var k = key;
+          if (k === '^null') {
+            return null;
+          } else if (k === '^undefined') {
+            return void 0;
+          } else {
+            var first = k.charAt(0);
+            if (first === '$') {
+              return _strSlice(k, 1);
+            } else if (first === 'n') {
+              return +_strSlice(k, 1);
+            } else if (first === 'b') {
+              return k === 'btrue';
             }
-
-            defineProperties(set, {
-              '[[SetData]]': null,
-              _storage: emptyObject()
+          }
+          return +k;
+        };
+        // Switch from the object backing storage to a full Map.
+        var ensureMap = function ensureMap(set) {
+          if (!set['[[SetData]]']) {
+            var m = set['[[SetData]]'] = new collectionShims.Map();
+            _forEach(keys(set._storage), function (key) {
+              var k = decodeKey(key);
+              m.set(k, k);
             });
+            set['[[SetData]]'] = m;
+          }
+          set._storage = null; // free old backing storage
+        };
 
-            // Optionally initialize map from iterable
-            if (iterable !== undefined && iterable !== null) {
-              var it = ES.GetIterator(iterable);
-              var adder = set.add;
-              if (!ES.IsCallable(adder)) { throw new TypeError('bad set'); }
-              while (true) {
-                var next = ES.IteratorNext(it);
-                if (next.done) { break; }
-                var nextItem = next.value;
-                adder.call(set, nextItem);
-              }
+        Value.getter(SetShim.prototype, 'size', function () {
+          requireSetSlot(this, 'size');
+          if (this._storage) {
+            return keys(this._storage).length;
+          }
+          ensureMap(this);
+          return this['[[SetData]]'].size;
+        });
+
+        defineProperties(SetShim.prototype, {
+          has: function has(key) {
+            requireSetSlot(this, 'has');
+            var fkey;
+            if (this._storage && (fkey = fastkey(key)) !== null) {
+              return !!this._storage[fkey];
             }
-            return set;
-          };
-          var Set$prototype = SetShim.prototype;
-          defineProperties(SetShim, {
-            '@@create': function (obj) {
-              var constructor = this;
-              var prototype = constructor.prototype || Set$prototype;
-              obj = obj || create(prototype);
-              defineProperties(obj, { _es6set: true });
-              return obj;
+            ensureMap(this);
+            return this['[[SetData]]'].has(key);
+          },
+
+          add: function add(key) {
+            requireSetSlot(this, 'add');
+            var fkey;
+            if (this._storage && (fkey = fastkey(key)) !== null) {
+              this._storage[fkey] = true;
+              return this;
             }
-          });
+            ensureMap(this);
+            this['[[SetData]]'].set(key, key);
+            return this;
+          },
 
-          // Switch from the object backing storage to a full Map.
-          var ensureMap = function ensureMap(set) {
-            if (!set['[[SetData]]']) {
-              var m = set['[[SetData]]'] = new collectionShims.Map();
-              Object.keys(set._storage).forEach(function (k) {
-                // fast check for leading '$'
-                if (k.charCodeAt(0) === 36) {
-                  k = k.slice(1);
-                } else if (k.charAt(0) === 'n') {
-                  k = +k.slice(1);
-                } else {
-                  k = +k;
-                }
-                m.set(k, k);
-              });
-              set._storage = null; // free old backing storage
+          'delete': function (key) {
+            requireSetSlot(this, 'delete');
+            var fkey;
+            if (this._storage && (fkey = fastkey(key)) !== null) {
+              var hasFKey = _hasOwnProperty(this._storage, fkey);
+              return (delete this._storage[fkey]) && hasFKey;
             }
-          };
+            ensureMap(this);
+            return this['[[SetData]]']['delete'](key);
+          },
 
-          Object.defineProperty(SetShim.prototype, 'size', {
-            configurable: true,
-            enumerable: false,
-            get: function () {
-              if (typeof this._storage === 'undefined') {
-                // https://github.com/paulmillr/es6-shim/issues/176
-                throw new TypeError('size method called on incompatible Set');
-              }
-              ensureMap(this);
-              return this['[[SetData]]'].size;
+          clear: function clear() {
+            requireSetSlot(this, 'clear');
+            if (this._storage) {
+              this._storage = emptyObject();
             }
-          });
-
-          defineProperties(SetShim.prototype, {
-            has: function (key) {
-              var fkey;
-              if (this._storage && (fkey = fastkey(key)) !== null) {
-                return !!this._storage[fkey];
-              }
-              ensureMap(this);
-              return this['[[SetData]]'].has(key);
-            },
-
-            add: function (key) {
-              var fkey;
-              if (this._storage && (fkey = fastkey(key)) !== null) {
-                this._storage[fkey] = true;
-                return;
-              }
-              ensureMap(this);
-              return this['[[SetData]]'].set(key, key);
-            },
-
-            'delete': function (key) {
-              var fkey;
-              if (this._storage && (fkey = fastkey(key)) !== null) {
-                delete this._storage[fkey];
-                return;
-              }
-              ensureMap(this);
-              return this['[[SetData]]']['delete'](key);
-            },
-
-            clear: function () {
-              if (this._storage) {
-                this._storage = emptyObject();
-                return;
-              }
-              return this['[[SetData]]'].clear();
-            },
-
-            keys: function () {
-              ensureMap(this);
-              return this['[[SetData]]'].keys();
-            },
-
-            values: function () {
-              ensureMap(this);
-              return this['[[SetData]]'].values();
-            },
-
-            entries: function () {
-              ensureMap(this);
-              return this['[[SetData]]'].entries();
-            },
-
-            forEach: function (callback) {
-              var context = arguments.length > 1 ? arguments[1] : null;
-              var entireSet = this;
-              ensureMap(this);
-              this['[[SetData]]'].forEach(function (value, key) {
-                callback.call(context, key, key, entireSet);
-              });
+            if (this['[[SetData]]']) {
+              this['[[SetData]]'].clear();
             }
-          });
-          addIterator(SetShim.prototype, function () { return this.values(); });
+          },
 
-          return SetShim;
-        })()
-      };
-      defineProperties(globals, collectionShims);
+          values: function values() {
+            requireSetSlot(this, 'values');
+            ensureMap(this);
+            return this['[[SetData]]'].values();
+          },
 
-      if (globals.Map || globals.Set) {
-        /*
-          - In Firefox < 23, Map#size is a function.
-          - In all current Firefox, Set#entries/keys/values & Map#clear do not exist
-          - https://bugzilla.mozilla.org/show_bug.cgi?id=869996
-          - In Firefox 24, Map and Set do not implement forEach
-          - In Firefox 25 at least, Map and Set are callable without "new"
-        */
-        if (
-          typeof globals.Map.prototype.clear !== 'function' ||
-          new globals.Set().size !== 0 ||
-          new globals.Map().size !== 0 ||
-          typeof globals.Map.prototype.keys !== 'function' ||
-          typeof globals.Set.prototype.keys !== 'function' ||
-          typeof globals.Map.prototype.forEach !== 'function' ||
-          typeof globals.Set.prototype.forEach !== 'function' ||
-          isCallableWithoutNew(globals.Map) ||
-          isCallableWithoutNew(globals.Set) ||
-          !supportsSubclassing(globals.Map, function (M) {
-            return (new M([])) instanceof M;
-          })
-        ) {
-          globals.Map = collectionShims.Map;
-          globals.Set = collectionShims.Set;
-        }
+          entries: function entries() {
+            requireSetSlot(this, 'entries');
+            ensureMap(this);
+            return this['[[SetData]]'].entries();
+          },
+
+          forEach: function forEach(callback) {
+            requireSetSlot(this, 'forEach');
+            var context = arguments.length > 1 ? arguments[1] : null;
+            var entireSet = this;
+            ensureMap(entireSet);
+            this['[[SetData]]'].forEach(function (value, key) {
+              if (context) {
+                _call(callback, context, key, key, entireSet);
+              } else {
+                callback(key, key, entireSet);
+              }
+            });
+          }
+        });
+        defineProperty(SetShim.prototype, 'keys', SetShim.prototype.values, true);
+        addIterator(SetShim.prototype, SetShim.prototype.values);
+
+        return SetShim;
+      }())
+    };
+
+    if (globals.Map || globals.Set) {
+      // Safari 8, for example, doesn't accept an iterable.
+      var mapAcceptsArguments = valueOrFalseIfThrows(function () { return new Map([[1, 2]]).get(1) === 2; });
+      if (!mapAcceptsArguments) {
+        var OrigMapNoArgs = globals.Map;
+        globals.Map = function Map() {
+          if (!(this instanceof Map)) {
+            throw new TypeError('Constructor Map requires "new"');
+          }
+          var m = new OrigMapNoArgs();
+          if (arguments.length > 0) {
+            addIterableToMap(Map, m, arguments[0]);
+          }
+          delete m.constructor;
+          Object.setPrototypeOf(m, globals.Map.prototype);
+          return m;
+        };
+        globals.Map.prototype = create(OrigMapNoArgs.prototype);
+        defineProperty(globals.Map.prototype, 'constructor', globals.Map, true);
+        Value.preserveToString(globals.Map, OrigMapNoArgs);
       }
+      var testMap = new Map();
+      var mapUsesSameValueZero = (function () {
+        // Chrome 38-42, node 0.11/0.12, iojs 1/2 also have a bug when the Map has a size > 4
+        var m = new Map([[1, 0], [2, 0], [3, 0], [4, 0]]);
+        m.set(-0, m);
+        return m.get(0) === m && m.get(-0) === m && m.has(0) && m.has(-0);
+      }());
+      var mapSupportsChaining = testMap.set(1, 2) === testMap;
+      if (!mapUsesSameValueZero || !mapSupportsChaining) {
+        var origMapSet = Map.prototype.set;
+        overrideNative(Map.prototype, 'set', function set(k, v) {
+          _call(origMapSet, this, k === 0 ? 0 : k, v);
+          return this;
+        });
+      }
+      if (!mapUsesSameValueZero) {
+        var origMapGet = Map.prototype.get;
+        var origMapHas = Map.prototype.has;
+        defineProperties(Map.prototype, {
+          get: function get(k) {
+            return _call(origMapGet, this, k === 0 ? 0 : k);
+          },
+          has: function has(k) {
+            return _call(origMapHas, this, k === 0 ? 0 : k);
+          }
+        }, true);
+        Value.preserveToString(Map.prototype.get, origMapGet);
+        Value.preserveToString(Map.prototype.has, origMapHas);
+      }
+      var testSet = new Set();
+      var setUsesSameValueZero = (function (s) {
+        s['delete'](0);
+        s.add(-0);
+        return !s.has(0);
+      }(testSet));
+      var setSupportsChaining = testSet.add(1) === testSet;
+      if (!setUsesSameValueZero || !setSupportsChaining) {
+        var origSetAdd = Set.prototype.add;
+        Set.prototype.add = function add(v) {
+          _call(origSetAdd, this, v === 0 ? 0 : v);
+          return this;
+        };
+        Value.preserveToString(Set.prototype.add, origSetAdd);
+      }
+      if (!setUsesSameValueZero) {
+        var origSetHas = Set.prototype.has;
+        Set.prototype.has = function has(v) {
+          return _call(origSetHas, this, v === 0 ? 0 : v);
+        };
+        Value.preserveToString(Set.prototype.has, origSetHas);
+        var origSetDel = Set.prototype['delete'];
+        Set.prototype['delete'] = function SetDelete(v) {
+          return _call(origSetDel, this, v === 0 ? 0 : v);
+        };
+        Value.preserveToString(Set.prototype['delete'], origSetDel);
+      }
+      var mapSupportsSubclassing = supportsSubclassing(globals.Map, function (M) {
+        var m = new M([]);
+        // Firefox 32 is ok with the instantiating the subclass but will
+        // throw when the map is used.
+        m.set(42, 42);
+        return m instanceof M;
+      });
+      var mapFailsToSupportSubclassing = Object.setPrototypeOf && !mapSupportsSubclassing; // without Object.setPrototypeOf, subclassing is not possible
+      var mapRequiresNew = (function () {
+        try {
+          return !(globals.Map() instanceof globals.Map);
+        } catch (e) {
+          return e instanceof TypeError;
+        }
+      }());
+      if (globals.Map.length !== 0 || mapFailsToSupportSubclassing || !mapRequiresNew) {
+        var OrigMap = globals.Map;
+        globals.Map = function Map() {
+          if (!(this instanceof Map)) {
+            throw new TypeError('Constructor Map requires "new"');
+          }
+          var m = new OrigMap();
+          if (arguments.length > 0) {
+            addIterableToMap(Map, m, arguments[0]);
+          }
+          delete m.constructor;
+          Object.setPrototypeOf(m, Map.prototype);
+          return m;
+        };
+        globals.Map.prototype = OrigMap.prototype;
+        defineProperty(globals.Map.prototype, 'constructor', globals.Map, true);
+        Value.preserveToString(globals.Map, OrigMap);
+      }
+      var setSupportsSubclassing = supportsSubclassing(globals.Set, function (S) {
+        var s = new S([]);
+        s.add(42, 42);
+        return s instanceof S;
+      });
+      var setFailsToSupportSubclassing = Object.setPrototypeOf && !setSupportsSubclassing; // without Object.setPrototypeOf, subclassing is not possible
+      var setRequiresNew = (function () {
+        try {
+          return !(globals.Set() instanceof globals.Set);
+        } catch (e) {
+          return e instanceof TypeError;
+        }
+      }());
+      if (globals.Set.length !== 0 || setFailsToSupportSubclassing || !setRequiresNew) {
+        var OrigSet = globals.Set;
+        globals.Set = function Set() {
+          if (!(this instanceof Set)) {
+            throw new TypeError('Constructor Set requires "new"');
+          }
+          var s = new OrigSet();
+          if (arguments.length > 0) {
+            addIterableToSet(Set, s, arguments[0]);
+          }
+          delete s.constructor;
+          Object.setPrototypeOf(s, Set.prototype);
+          return s;
+        };
+        globals.Set.prototype = OrigSet.prototype;
+        defineProperty(globals.Set.prototype, 'constructor', globals.Set, true);
+        Value.preserveToString(globals.Set, OrigSet);
+      }
+      var newMap = new globals.Map();
+      var mapIterationThrowsStopIterator = !valueOrFalseIfThrows(function () {
+        return newMap.keys().next().done;
+      });
+      /*
+        - In Firefox < 23, Map#size is a function.
+        - In all current Firefox, Set#entries/keys/values & Map#clear do not exist
+        - https://bugzilla.mozilla.org/show_bug.cgi?id=869996
+        - In Firefox 24, Map and Set do not implement forEach
+        - In Firefox 25 at least, Map and Set are callable without "new"
+      */
+      if (
+        typeof globals.Map.prototype.clear !== 'function' ||
+        new globals.Set().size !== 0 ||
+        newMap.size !== 0 ||
+        typeof globals.Map.prototype.keys !== 'function' ||
+        typeof globals.Set.prototype.keys !== 'function' ||
+        typeof globals.Map.prototype.forEach !== 'function' ||
+        typeof globals.Set.prototype.forEach !== 'function' ||
+        isCallableWithoutNew(globals.Map) ||
+        isCallableWithoutNew(globals.Set) ||
+        typeof newMap.keys().next !== 'function' || // Safari 8
+        mapIterationThrowsStopIterator || // Firefox 25
+        !mapSupportsSubclassing
+      ) {
+        defineProperties(globals, {
+          Map: collectionShims.Map,
+          Set: collectionShims.Set
+        }, true);
+      }
+
+      if (globals.Set.prototype.keys !== globals.Set.prototype.values) {
+        // Fixed in WebKit with https://bugs.webkit.org/show_bug.cgi?id=144190
+        defineProperty(globals.Set.prototype, 'keys', globals.Set.prototype.values, true);
+      }
+
       // Shim incomplete iterator implementations.
       addIterator(Object.getPrototypeOf((new globals.Map()).keys()));
       addIterator(Object.getPrototypeOf((new globals.Set()).keys()));
+
+      if (functionsHaveNames && globals.Set.prototype.has.name !== 'has') {
+        // Microsoft Edge v0.11.10074.0 is missing a name on Set#has
+        var anonymousSetHas = globals.Set.prototype.has;
+        overrideNative(globals.Set.prototype, 'has', function has(key) {
+          return _call(anonymousSetHas, this, key);
+        });
+      }
+    }
+    defineProperties(globals, collectionShims);
+    addDefaultSpecies(globals.Map);
+    addDefaultSpecies(globals.Set);
+  }
+
+  var throwUnlessTargetIsObject = function throwUnlessTargetIsObject(target) {
+    if (!ES.TypeIsObject(target)) {
+      throw new TypeError('target must be an object');
     }
   };
 
-  if (typeof define === 'function' && define.amd) {
-    define(main); // RequireJS
-  } else {
-    main(); // CommonJS and <script>
-  }
-})();
+  // Some Reflect methods are basically the same as
+  // those on the Object global, except that a TypeError is thrown if
+  // target isn't an object. As well as returning a boolean indicating
+  // the success of the operation.
+  var ReflectShims = {
+    // Apply method in a functional form.
+    apply: function apply() {
+      return ES.Call(ES.Call, null, arguments);
+    },
 
+    // New operator in a functional form.
+    construct: function construct(constructor, args) {
+      if (!ES.IsConstructor(constructor)) {
+        throw new TypeError('First argument must be a constructor.');
+      }
+      var newTarget = arguments.length > 2 ? arguments[2] : constructor;
+      if (!ES.IsConstructor(newTarget)) {
+        throw new TypeError('new.target must be a constructor.');
+      }
+      return ES.Construct(constructor, args, newTarget, 'internal');
+    },
+
+    // When deleting a non-existent or configurable property,
+    // true is returned.
+    // When attempting to delete a non-configurable property,
+    // it will return false.
+    deleteProperty: function deleteProperty(target, key) {
+      throwUnlessTargetIsObject(target);
+      if (supportsDescriptors) {
+        var desc = Object.getOwnPropertyDescriptor(target, key);
+
+        if (desc && !desc.configurable) {
+          return false;
+        }
+      }
+
+      // Will return true.
+      return delete target[key];
+    },
+
+    has: function has(target, key) {
+      throwUnlessTargetIsObject(target);
+      return key in target;
+    }
+  };
+
+  if (Object.getOwnPropertyNames) {
+    Object.assign(ReflectShims, {
+      // Basically the result of calling the internal [[OwnPropertyKeys]].
+      // Concatenating propertyNames and propertySymbols should do the trick.
+      // This should continue to work together with a Symbol shim
+      // which overrides Object.getOwnPropertyNames and implements
+      // Object.getOwnPropertySymbols.
+      ownKeys: function ownKeys(target) {
+        throwUnlessTargetIsObject(target);
+        var keys = Object.getOwnPropertyNames(target);
+
+        if (ES.IsCallable(Object.getOwnPropertySymbols)) {
+          _pushApply(keys, Object.getOwnPropertySymbols(target));
+        }
+
+        return keys;
+      }
+    });
+  }
+
+  var callAndCatchException = function ConvertExceptionToBoolean(func) {
+    return !throwsError(func);
+  };
+
+  if (Object.preventExtensions) {
+    Object.assign(ReflectShims, {
+      isExtensible: function isExtensible(target) {
+        throwUnlessTargetIsObject(target);
+        return Object.isExtensible(target);
+      },
+      preventExtensions: function preventExtensions(target) {
+        throwUnlessTargetIsObject(target);
+        return callAndCatchException(function () {
+          Object.preventExtensions(target);
+        });
+      }
+    });
+  }
+
+  if (supportsDescriptors) {
+    var internalGet = function get(target, key, receiver) {
+      var desc = Object.getOwnPropertyDescriptor(target, key);
+
+      if (!desc) {
+        var parent = Object.getPrototypeOf(target);
+
+        if (parent === null) {
+          return void 0;
+        }
+
+        return internalGet(parent, key, receiver);
+      }
+
+      if ('value' in desc) {
+        return desc.value;
+      }
+
+      if (desc.get) {
+        return ES.Call(desc.get, receiver);
+      }
+
+      return void 0;
+    };
+
+    var internalSet = function set(target, key, value, receiver) {
+      var desc = Object.getOwnPropertyDescriptor(target, key);
+
+      if (!desc) {
+        var parent = Object.getPrototypeOf(target);
+
+        if (parent !== null) {
+          return internalSet(parent, key, value, receiver);
+        }
+
+        desc = {
+          value: void 0,
+          writable: true,
+          enumerable: true,
+          configurable: true
+        };
+      }
+
+      if ('value' in desc) {
+        if (!desc.writable) {
+          return false;
+        }
+
+        if (!ES.TypeIsObject(receiver)) {
+          return false;
+        }
+
+        var existingDesc = Object.getOwnPropertyDescriptor(receiver, key);
+
+        if (existingDesc) {
+          return Reflect.defineProperty(receiver, key, {
+            value: value
+          });
+        } else {
+          return Reflect.defineProperty(receiver, key, {
+            value: value,
+            writable: true,
+            enumerable: true,
+            configurable: true
+          });
+        }
+      }
+
+      if (desc.set) {
+        _call(desc.set, receiver, value);
+        return true;
+      }
+
+      return false;
+    };
+
+    Object.assign(ReflectShims, {
+      defineProperty: function defineProperty(target, propertyKey, attributes) {
+        throwUnlessTargetIsObject(target);
+        return callAndCatchException(function () {
+          Object.defineProperty(target, propertyKey, attributes);
+        });
+      },
+
+      getOwnPropertyDescriptor: function getOwnPropertyDescriptor(target, propertyKey) {
+        throwUnlessTargetIsObject(target);
+        return Object.getOwnPropertyDescriptor(target, propertyKey);
+      },
+
+      // Syntax in a functional form.
+      get: function get(target, key) {
+        throwUnlessTargetIsObject(target);
+        var receiver = arguments.length > 2 ? arguments[2] : target;
+
+        return internalGet(target, key, receiver);
+      },
+
+      set: function set(target, key, value) {
+        throwUnlessTargetIsObject(target);
+        var receiver = arguments.length > 3 ? arguments[3] : target;
+
+        return internalSet(target, key, value, receiver);
+      }
+    });
+  }
+
+  if (Object.getPrototypeOf) {
+    var objectDotGetPrototypeOf = Object.getPrototypeOf;
+    ReflectShims.getPrototypeOf = function getPrototypeOf(target) {
+      throwUnlessTargetIsObject(target);
+      return objectDotGetPrototypeOf(target);
+    };
+  }
+
+  if (Object.setPrototypeOf && ReflectShims.getPrototypeOf) {
+    var willCreateCircularPrototype = function (object, lastProto) {
+      var proto = lastProto;
+      while (proto) {
+        if (object === proto) {
+          return true;
+        }
+        proto = ReflectShims.getPrototypeOf(proto);
+      }
+      return false;
+    };
+
+    Object.assign(ReflectShims, {
+      // Sets the prototype of the given object.
+      // Returns true on success, otherwise false.
+      setPrototypeOf: function setPrototypeOf(object, proto) {
+        throwUnlessTargetIsObject(object);
+        if (proto !== null && !ES.TypeIsObject(proto)) {
+          throw new TypeError('proto must be an object or null');
+        }
+
+        // If they already are the same, we're done.
+        if (proto === Reflect.getPrototypeOf(object)) {
+          return true;
+        }
+
+        // Cannot alter prototype if object not extensible.
+        if (Reflect.isExtensible && !Reflect.isExtensible(object)) {
+          return false;
+        }
+
+        // Ensure that we do not create a circular prototype chain.
+        if (willCreateCircularPrototype(object, proto)) {
+          return false;
+        }
+
+        Object.setPrototypeOf(object, proto);
+
+        return true;
+      }
+    });
+  }
+  var defineOrOverrideReflectProperty = function (key, shim) {
+    if (!ES.IsCallable(globals.Reflect[key])) {
+      defineProperty(globals.Reflect, key, shim);
+    } else {
+      var acceptsPrimitives = valueOrFalseIfThrows(function () {
+        globals.Reflect[key](1);
+        globals.Reflect[key](NaN);
+        globals.Reflect[key](true);
+        return true;
+      });
+      if (acceptsPrimitives) {
+        overrideNative(globals.Reflect, key, shim);
+      }
+    }
+  };
+  Object.keys(ReflectShims).forEach(function (key) {
+    defineOrOverrideReflectProperty(key, ReflectShims[key]);
+  });
+  var originalReflectGetProto = globals.Reflect.getPrototypeOf;
+  if (functionsHaveNames && originalReflectGetProto && originalReflectGetProto.name !== 'getPrototypeOf') {
+    overrideNative(globals.Reflect, 'getPrototypeOf', function getPrototypeOf(target) {
+      return _call(originalReflectGetProto, globals.Reflect, target);
+    });
+  }
+  if (globals.Reflect.setPrototypeOf) {
+    if (valueOrFalseIfThrows(function () {
+      globals.Reflect.setPrototypeOf(1, {});
+      return true;
+    })) {
+      overrideNative(globals.Reflect, 'setPrototypeOf', ReflectShims.setPrototypeOf);
+    }
+  }
+  if (globals.Reflect.defineProperty) {
+    if (!valueOrFalseIfThrows(function () {
+      var basic = !globals.Reflect.defineProperty(1, 'test', { value: 1 });
+      // "extensible" fails on Edge 0.12
+      var extensible = typeof Object.preventExtensions !== 'function' || !globals.Reflect.defineProperty(Object.preventExtensions({}), 'test', {});
+      return basic && extensible;
+    })) {
+      overrideNative(globals.Reflect, 'defineProperty', ReflectShims.defineProperty);
+    }
+  }
+  if (globals.Reflect.construct) {
+    if (!valueOrFalseIfThrows(function () {
+      var F = function F() {};
+      return globals.Reflect.construct(function () {}, [], F) instanceof F;
+    })) {
+      overrideNative(globals.Reflect, 'construct', ReflectShims.construct);
+    }
+  }
+
+  if (String(new Date(NaN)) !== 'Invalid Date') {
+    var dateToString = Date.prototype.toString;
+    var shimmedDateToString = function toString() {
+      var valueOf = +this;
+      if (valueOf !== valueOf) {
+        return 'Invalid Date';
+      }
+      return ES.Call(dateToString, this);
+    };
+    overrideNative(Date.prototype, 'toString', shimmedDateToString);
+  }
+
+  // Annex B HTML methods
+  // http://www.ecma-international.org/ecma-262/6.0/#sec-additional-properties-of-the-string.prototype-object
+  var stringHTMLshims = {
+    anchor: function anchor(name) { return ES.CreateHTML(this, 'a', 'name', name); },
+    big: function big() { return ES.CreateHTML(this, 'big', '', ''); },
+    blink: function blink() { return ES.CreateHTML(this, 'blink', '', ''); },
+    bold: function bold() { return ES.CreateHTML(this, 'b', '', ''); },
+    fixed: function fixed() { return ES.CreateHTML(this, 'tt', '', ''); },
+    fontcolor: function fontcolor(color) { return ES.CreateHTML(this, 'font', 'color', color); },
+    fontsize: function fontsize(size) { return ES.CreateHTML(this, 'font', 'size', size); },
+    italics: function italics() { return ES.CreateHTML(this, 'i', '', ''); },
+    link: function link(url) { return ES.CreateHTML(this, 'a', 'href', url); },
+    small: function small() { return ES.CreateHTML(this, 'small', '', ''); },
+    strike: function strike() { return ES.CreateHTML(this, 'strike', '', ''); },
+    sub: function sub() { return ES.CreateHTML(this, 'sub', '', ''); },
+    sup: function sub() { return ES.CreateHTML(this, 'sup', '', ''); }
+  };
+  _forEach(Object.keys(stringHTMLshims), function (key) {
+    var method = String.prototype[key];
+    var shouldOverwrite = false;
+    if (ES.IsCallable(method)) {
+      var output = _call(method, '', ' " ');
+      var quotesCount = _concat([], output.match(/"/g)).length;
+      shouldOverwrite = output !== output.toLowerCase() || quotesCount > 2;
+    } else {
+      shouldOverwrite = true;
+    }
+    if (shouldOverwrite) {
+      overrideNative(String.prototype, key, stringHTMLshims[key]);
+    }
+  });
+
+  var JSONstringifiesSymbols = (function () {
+    // Microsoft Edge v0.12 stringifies Symbols incorrectly
+    if (!hasSymbols) { return false; } // Symbols are not supported
+    var stringify = typeof JSON === 'object' && typeof JSON.stringify === 'function' ? JSON.stringify : null;
+    if (!stringify) { return false; } // JSON.stringify is not supported
+    if (typeof stringify(Symbol()) !== 'undefined') { return true; } // Symbols should become `undefined`
+    if (stringify([Symbol()]) !== '[null]') { return true; } // Symbols in arrays should become `null`
+    var obj = { a: Symbol() };
+    obj[Symbol()] = true;
+    if (stringify(obj) !== '{}') { return true; } // Symbol-valued keys *and* Symbol-valued properties should be omitted
+    return false;
+  }());
+  var JSONstringifyAcceptsObjectSymbol = valueOrFalseIfThrows(function () {
+    // Chrome 45 throws on stringifying object symbols
+    if (!hasSymbols) { return true; } // Symbols are not supported
+    return JSON.stringify(Object(Symbol())) === '{}' && JSON.stringify([Object(Symbol())]) === '[{}]';
+  });
+  if (JSONstringifiesSymbols || !JSONstringifyAcceptsObjectSymbol) {
+    var origStringify = JSON.stringify;
+    overrideNative(JSON, 'stringify', function stringify(value) {
+      if (typeof value === 'symbol') { return; }
+      var replacer;
+      if (arguments.length > 1) {
+        replacer = arguments[1];
+      }
+      var args = [value];
+      if (!isArray(replacer)) {
+        var replaceFn = ES.IsCallable(replacer) ? replacer : null;
+        var wrappedReplacer = function (key, val) {
+          var parsedValue = replaceFn ? _call(replaceFn, this, key, val) : val;
+          if (typeof parsedValue !== 'symbol') {
+            if (Type.symbol(parsedValue)) {
+              return assignTo({})(parsedValue);
+            } else {
+              return parsedValue;
+            }
+          }
+        };
+        args.push(wrappedReplacer);
+      } else {
+        // create wrapped replacer that handles an array replacer?
+        args.push(replacer);
+      }
+      if (arguments.length > 2) {
+        args.push(arguments[2]);
+      }
+      return origStringify.apply(this, args);
+    });
+  }
+
+  return globals;
+}));


### PR DESCRIPTION
The main reason for this upgrade is that the existing es6-shim version was suppressing certain Promise errors.

The `es6-shim.js` file is copied from: https://github.com/paulmillr/es6-shim/blob/3e46993a95b1867665166e0290e5cbaaf2ccb2f6/es6-shim.js

----

Here's the exact list of changes (between 0.18.0 and 0.35.1):

### Breaking:

* [Breaking] remove `Reflect.enumerate` (#405)
* [Breaking] Remove `Symbol.species` from `Promise.all` and `Promise.race` (#34)
* [Breaking] Avoid CSP errors in Chrome apps by using global var detection (#301)
* String.contains -> String.includes
* Remove non-spec Object.{getPropertyNames,getPropertyDescriptor}


### All:

# es6-shim 0.35.1 (12 May 2016)
* [Fix] Functions are objects (#418)
* [Fix] use `createDataPropertyOrThrow` in `Array.from`, rather than `[[Put]]` (#415)
* [Refactor] Use `iteratorResult` internally for iterator result objects
* [Refactor] Simplify logic for Math.tanh (#412)
* [Robustness] cache `Math` constants
* [Robustness] cache `Math.exp`
* [Robustness] don’t rely on a `Math` lookup inside `Math.asinh`
* [Robustness] use cached `Number.isNaN`
* [Robustness] cache `Math.sign`
* [Dev Deps] update `es5-shim`, `eslint`, `@ljharb/eslint-config`, `jscs`, `uglify-js`, `grunt-contrib-connect`, `grunt-contrib-watch`, `evalmd`, `jshint`
* [Tests] up to `node` `v6.1`, `v5.10`, `v4.4`
* [Tests] `npm run --silent`, use “pretest” for linting
* [Tests] `RegExp#toString`: Chrome Canary 51 produces `/undefined/`
* [Docs] update ES6 draft comment URLs to point to the published spec

# es6-shim 0.35.0 (29 Feb 2016)
* [Breaking] remove `Reflect.enumerate` (#405)
* [New] Add `Array#indexOf` from post-ES6 errata
* [New] Ensure `RegExp#toString` is compliant
* [New] [sham] Add `Function#toString` to `es6-sham`
* [Fix] ensure that a non-object `globals.Reflect` doesn’t break the shim (#392)
* [Fix] In ES3 browsers (like Safari 4) `Reflect.getPrototypeOf` is undefined
* [Fix] `Object.keys`: handle regexes in ES3 browsers (#287)
* [Performance] Early exit from tanh for values outside of +-20 at limits of JS precision (#411)
* [Tests] `Function#name` on `new Function`s is empty string in v8
* [Tests] `Function#name` is non-configurable pre-ES6
* [Tests] up to `node` `v5.7`, `v4.3`
* [Docs] correct readme; we sham Function#name, not toString

# es6-shim 0.34.4 (9 Feb 2016)
* [Fix] 'Uncaught (in promise) TypeError' in Chrome 48 (#408, #407)
* [Fix] handle the obscure case where `startsWith` throws on the second parameter (#399)
* [Tests] silence a promise rejection error in Chrome

# es6-shim 0.34.3 (8 Feb 2016)
* [Fix] Suppress “uncaught rejection” warnings in Chrome 50 console (#403)
* [Fix] ensure ES3 `Number` constants don’t get lost in ES3 browsers (#402)
* [Dev Deps] update `chai`, `es5-shim`, `jscs`, `mocha`
* [Tests] up to `node` `v5.5`

# es6-shim 0.34.2 (22 Jan 2016)
* [Fix] `JSON.stringify` should ignore a replacer arg unless it’s an array or function.
* [Fix] `Array#copyWithin`: check for inherited properties as well
* [Fix] `Array#copyWithin`: should delete the target key if the source key is not present
* [Performance] Optimize Map/Set fast key path (#397)
* [Tests] fix `Reflect.enumerate` tests to not call `next` too many times
* [Dev Deps] update `jscs`, `jshint`
* [Docs] update license year to 2016 (#400)

# es6-shim 0.34.1 (5 Jan 2016)
* [Fix] `RegExp#[Symbol.search]` was broken with a regex argument (#394)
* [Fix] ensure that Set#clear works with both primitive and object values
* [Fix] static Promise methods have the wrong length in Firefox
* [Robustness] Cache `Object.keys`
* [Performance] Avoid accessing arguments array without length check
* [Performance] Optimize ES.TypeIsObject (#388)
* [Performance] Promises: lots of improvements (#383)
* [Performance] Only use slow implementation of IsCallable where necessary (old browsers)
* [Performance] Promises: remove unnecessary `.bind` on `setImmediate`
* [Refactor] extract “decode fast Map key” logic
* [Dev Deps] update `s5-shim`, `@ljharb/eslint-config`
* Don’t npmignore tests
* [Tests] Fix a bug with “deep equal” wrt NaN
* [Tests] split up Map and Set test files
* [Tests] up to `node` `v5.3`

# es6-shim 0.34.0 (14 Dec 2015)
* [Breaking] Remove `Symbol.species` from `Promise.all` and `Promise.race` (#34)
* [Fix] Firefox has enumerable Promise static methods
* [Fix] prevent crashes in older Firefox when checking if Array methods ToLength correctly
* [Fix] `Reflect.enumerate`: ensure correct property ordering in Firefox 19 (and likely others)
* [Fix] Ensure that `toLengthsCorrectly` returns `true` when it passes, instead of `undefined`
* [Fix] Don't call `Reflect.construct` unless it's actually present
* [Fix] Ensure `Map` and `Set` do not have an own `constructor` property (#368)
* [Fix] Add missing checks to Promise.resolve and Promise.reject (#379)
* [Fix] `Map`: older v8s have a SameValueZero bug when a Map has a size > 4 (#378)
* [Fix] `Map`: when provided with an iterable that yields non-Object values, should throw
* [Fix] `Promise`: Make sure to shim broken implementations in Chrome 49 Canary
* [Fix] `Promise`: Chrome does not retrieve a thenable's .then synchronously (#372)
* [New] Add `RegExp.prototype[Symbol.{match,search,split,replace}]`
* [New] support `Symbol.match` in `RegExp` constructor
* [New] add `Symbol.match` and ensure `String#{match, startsWith, endsWith, includes}` support it
* [New] add `Symbol.split` and ensure `String#split` supports it
* [New] add `Symbol.replace` and ensure `String#replace` supports it
* [New] add `Symbol.search` and ensure `String#search` supports it
* [Robustness] Add and use `ES.ToString` so as not to rely on the global `String`
* [Dev Deps] update `eslint`, `jscs`, `mocha`, `uglify-js`, `es5-shim`, `grunt-saucelabs`
* [Tests] bailing out of some tests when the feature isn't present, to clean up native test failure output
* [Tests] up to `node` `v5.2`
* [Tests] fix `npm run test:native`
* [Tests] Ensure `Promise.{reject,resolve}` throws when the receiver is a primitive (#379)
* [Tests] Further ensure that Promise.resolve/reject work with a non-promise receiver (#379)
* [Docs] update README URLs (#375)
* [Docs] fix some typos (#380)

# es6-shim 0.33.13 (12 Nov 2015)
* [Fix] `Number`: when no arguments are passed, return `+0`.
* [Fix] `Number`: Make sure string values are trimmed before attempting to parse.
* [Tests] cleaning up `Number` tests)
* [Dev Deps] update `uglify-js`

# es6-shim 0.33.12 (11 Nov 2015)
* [Fix] IE 8: more NFE madness.
* [Dev Deps] update `es5-shim`
* [Docs] removing now-fixed `Number` caveat
* [Docs] use assertions so `evalmd` will test the readme better.
* [Docs] fix incorrect isFinite note (#373)

# es6-shim 0.33.11 (9 Nov 2015)
* [Fix] handle future change of RegExp.prototype not being a regex (#370, #371)
* [Fix] disallow invalid hex strings in `Number` (#369)
* [Tests] Tweak "polluted prototype" approach
* [Dev Deps] update `chai`, `es5-shim`, `eslint`, `@ljharb/eslint-config`, `jscs`

# es6-shim 0.33.10 (2 Nov 2015)
* [Fix] the `Number` constructor properly trims (or not) whitespace characters (#368)
* [Fix] `Number('0b12')` and `Number('0o18')` should both be `NaN` (#366)
* [Tests] Fix npm upgrades in older nodes
* [Tests] add `npm run tests-only`
* [Tests] on `node` `v5.0`
* [Tests] ensure `JSON.stringify` has the right name
* [Tests] add `npm run eslint`
* [Dev Deps] update `es5-shim`, `jscs`
* [Cleanup] Rearrange things so that they’re defined before they’re used
* [Cleanup] Don't reassign to function or catch parameters
* [Cleanup] Remove unused variables
* [Refactor] String#trim shim should use `defineProperty`, and check more non-whitespace chars

# es6-shim 0.33.9 (29 Oct 2015)
* [Fix] IE 8: `Number(new Number(1))` was throwing. More NFE madness. (#365)

# es6-shim 0.33.8 (23 Oct 2015)
* [Fix] IE 8: `Promise.resolve(2)` was throwing. More named function expression madness.
* [Tests] Reflect: Don't attempt to define properties on this test object unless we're in true ES5.

# es6-shim 0.33.7 (23 Oct 2015)
* [Fix] Ensure `preserveToString` does not throw when the original does not exist (#359)
* [Fix] `Promise`: properly handle named function expressions in IE 8.
* [Fix] `Number`: `wrapConstructor` now works in ES3 (#365)
* [Docs] Document `Number` supporting string binary and octal literals.
* [Tests] add commented-out test for `typeof Number.call(Object(3), 3) === 'number'`, which fails atm.
* [Tests] Fix browser tests sans-`npm install`
* [Dev Deps] update `es5-shim`, `jscs`, `uglify-js`, `chai`

# es6-shim 0.33.6 (29 Sep 2015)
* [Fix] In IE 6-8, of course, `typeof setTimeout` is "object"
* [Tests] Upgrade jQuery on the test HTML pages

# es6-shim 0.33.5 (28 Sep 2015)
* [Fix] IE 6-8 have wacky scoping issues with named function expressions.
* [Fix] Apparently in IE 8, RegExp#test is an own property of regexes, not a prototype method
* [Fix] Make sure to treat `es5-sham`'s `Object.defineProperty` as unsupported, in IE 8

# es6-shim 0.33.4 (27 Sep 2015)
* [Fix] Add test, and fix, for `JSON.stringify(Object(Symbol()))` throwing on Chrome 45
* [Fix] Wrap `JSON.stringify` when `Symbol` exists and it fails to serialize them correctly
* [Fix] fix `Reflect.defineProperty` on edge v0.12
* [Robustness] Cache `Array.isArray` internally
* [Refactor] Use internal `overrideNative` helper for String.prototype HTML methods
* [Refactor] Update `is-arguments` implementation; don't call down legacy code path in modern engines
* [Tests] Add `evalmd` to verify that example code blocks are valid
* [Tests] Adding a test for Safari 7.1 and later (runtime check added in 8a8ddd36186cdc1fcb3fcc259ec9ecef1e141901)
* [Tests] Add additional `JSON.stringify` test for `Symbol` and object `Symbol` values
* [Tests] up to `io.js` `v3.3`, `node` `v4.1`
* [Dev Deps] update `es5-shim`, `mocha`, `chai`

# es6-shim 0.33.3 (31 Aug 2015)
* [Fix] Handle Firefox Nightly's broken `construct` method
* [Tests] Add `JSON.stringify` tests for handling `Symbol`s

# es6-shim 0.33.2 (26 Aug 2015)
* [Fix] Make sure that minified code preserves function names.
* [Fix] Skip the `Promise` shim when `setTimeout` is not available ([#301](https://github.com/paulmillr/es6-shim/issues/301#issuecomment-126566703))
* [Docs] Add note about `setPrototypeOf` on null objects

# es6-shim 0.33.1 (20 Aug 2015)
* [New] Add support for binary and octal literals in strings to the `Number` constructor (#358)
* [Docs] Update spec link to final spec
* [Fix] `Reflect.enumerate`: does not necessarily wait until the first `next()` to determine keys.
* [Refactors] split up some tests; name some functions; remove unnecessary code
* {Refactors] make ObjectIterator properties non-enumerable
* [Refactors] Refactor `RegExp` wrapping code so most of it can be reused.
* [Tests] up to `io.js` `v3.1`
* [Dev Deps] update `grunt-contrib-connect`, `jscs`

# es6-shim 0.33.0 (30 Jul 2015)
* [Breaking] Avoid CSP errors in Chrome apps by using global var detection (#301)
* [Performance] Rearranging some of the Map/Set runtime shim clobberings to be more efficient.
* [Refactor] Implement `Array.of` directly, rather than in terms of `Array.from`
* [Dev Deps] Update `chai`, `es5-shim`, `promises-aplus-tests`, `uglify-js`
* [Tests] Add test for `Object.getPrototypeOf` accepting primitives.
* [Tests] Bail out of individual `Reflect` tests when the methods don’t exist
* [Tests] Test on latest `io.js`

# es6-shim 0.32.3 (21 Jun 2015)
* [Fix] Override or wrap native `Reflect` methods in Microsoft Edge v0.11 as required.
* [Fix] Edge v0.11: `Array.from([], undefined)` should not throw
* [Fix] Fix a bug in `Array.from handles iterables` runtime clobbering, which would always replace the native function
* [Fix] Ensure that `Set#has` has the correct name in Edge v0.11
* [Tests] Add `Map`/`Set` error messages for Edge v0.11
* [Tests] Fix `Math.fround` test value for Edge v0.11
* [Tests] Bail out of `Map`/`Set` test blocks if they don't exist
* [Docs] Update ES5 subclassing instructions in the README.
* [Dev Deps] Update `es5-shim`

# es6-shim 0.32.2 (17 Jun 2015)
* [Fix] `Object.assign` with no sources should coerce to an object (#348)
* [Fix] `String#includes` should throw when given a `RegExp` (#349)
* [Fix] `RegExp()` should not throw (#350)
* [Fix] Create `Value.defineByDescriptor`, fix `create` when `Object.create` is unavailable.
* [Compliance] Update `Promise.reject` to match official ECMA-262 spec.
* [Dev Deps] Update `es5-shim`

# es6-shim 0.32.1 (13 Jun 2015)
* [Fix] Make sure that all `Map`/`Set` shim forms properly add an iterable to the collection instance.
* [Tests] Make sure none of the `Array` ToLength tests throw *any* error (#347)

# es6-shim 0.32.0 (7 Jun 2015)
* [Spec compliance] Update Promises to match finalized ES6 spec (#345, #344, #239)
* [Fix] Ensure `Map`, `Set`, and `Promise` shims all throw when used without "new".
* [Tests] Fix the pending exceptions test for Safari 5.1
* [Refactor] Since the String HTML shims will be iterated anyways, no need to defineProperties them twice.
* [Deps] Update `chai`, `es5-shim`

# es6-shim 0.31.3 (2 Jun 2015)
* [Fix] Properly name more shim functions
* [Fix] Fix an IE bug where the layout engine internally calls the userland `Object.getOwnPropertyNames`
* [Fix] Ensure `Map.prototype[Symbol.iterator] === Map.prototype.entries`
* [Fix] Ensure `Set.prototype[Symbol.iterator] === Set.prototype.values`
* [Tests] `Object.assign` pending exceptions: IE 9 `preventExtensions` doesn't throw, even in strict mode
* [Security] Cache more native methods in case they're overwritten later
* [Tests] IE 11 has native `Map`/`Set`, but it takes an optional *function*, not an optional iterable, in the constructor
* [Tests] Add more "exists" early bailouts, to declutter native test results
* [Docs] Alphabetize shim lists in the README
* [Perf] Add more `Map`/`Set` fast paths for more primitives: boolean, null, undefined
* [Tests] Test up to `io.js` `v2.2`
* [Deps] Update `mocha`, `es5-shim`, `uglify-js`, `jshint`
* [Refactor] Style cleanups

# es6-shim 0.31.2 (9 May 2015)
* Fix ES5 `Array.prototype` method wrappers to return the correct value. (#341)

# es6-shim 0.31.1 (7 May 2015)
* `RegExp` should work properly as a wrapper (#340)

# es6-shim 0.31.0 (1 May 2015)
* All Array.prototype methods should use `ToLength`, not `ToUint32`, on `this.length`.
* Preserve and use original Array.prototype functions (for later shimming)
* Make String#{startsWith, endsWith, includes} tests a bit more granular.
* Fix Map/Set invalid receiver error messages for WebKit
* Update `grunt-saucelabs`, `jscs`

# es6-shim 0.30.0 (26 Apr 2015)
* `Map` and `Set` methods are not generic, and must only be called on valid `Map` and `Set` objects.
* Use the native `Number#clz` (in Safari 8, eg) inside `Math.clz32`

# es6-shim 0.29.0 (26 Apr 2015)
* Test on `io.js` `v1.7` and `v1.8`
* Ensure that shallowly wrapped Maps’ and Sets’ prototypes aren't one level too far away.
* Update `chai` and use new matchers
* Avoid reassigning argument variables to avoid deoptimizations
* Ensure that ES3 browsers get both `Object.is` and `Object.assign`
* Improve `Object.assign` to avoid leaking arguments in v8
* Ensuring `Number.parseInt === parseInt` (failed in FF 37)
* a little more accurate Math.cbrt (#335)
* Test cleanups
* Adding `Symbol.unscopables` tests
* Adding tests to ensure that default iterators on builtins === the appropriate prototype function.

# es6-shim 0.28.2 (13 Apr 2015)
* `Map` and `Set` should have an arity of 0.

# es6-shim 0.28.1 (12 Apr 2015)
* Ensure `Object.assign` only includes enumerable Symbols.

# es6-shim 0.28.0 (12 Apr 2015)
* Ensure `Object.assign` also includes Symbols.
* Make sure to clobber Firefox 37's very slow native Object.assign, that has "pending exception" logic.
* Adding much more granular Set/Map acceptance tests and replacements, to preserve as much of the original implementation as possible. (#326, #328)
* Lots of test additions and cleanup
 * Fill in (and fix) missing name, arity, and enumerability tests.
 * Using `property` matcher for a more helpful failure message.
 * Make sure this test doesn't fail if `Array#values` doesn't exist yet.
 * Make this `@@iterator` test not depend on `Array#values`, and properly skip tests if the symbol isn't available.
* Update `Math.fround` with a much smaller implementation (#332)
* Lock `uglify-js` down to v2.4.17, since v2.4.18 and v2.4.19 have a breaking change.
* Update `es5-shim`, `mocha`, `grunt-contrib-connect`, `chai`, `jshint`
* IE 11 TP has a broken `String.raw` implementation
* Overwriting some imprecise Math functions on IE 11 TP.
* Overwrite `Math.imul` in Safari 8 to report the correct length.
* Fix Math.round for very large numbers
* Don't rely on shims in tests, for better native failure checking.
* Shim `Object.is` in ES3 environments, and add tests.
* Test the native `Object.assign` prior to shimming it.
* Tweak the `travis-ci` config to make a separate "lint only" test run.
* Fix Firefox 4 test failures: ensure RegExp global aliases starting with "$" exist.
* more efficient Math.clz32 (#327)
* Fix Webkit nightly bugs with `Array.from` and `Array.of`.
* Make sure shims that depend on `Number.isNaN` and `Number.isFinite` will always work.
* The latest Webkit nightly has a bug with `String#includes` and a position arg of `Infinity`.
* Webkit r181855 has a noncompliant `String#startsWith` and `String#endsWith`
* Clean up README; add more accurate note about `es5-shim`.
* Updating the `String.raw` code to be more in line with the changes in RC2/Rev 35 of the spec.

# es6-shim 0.27.1 (5 Mar 2015)
* Revert `Array#slice` changes. (#322)
* Test on `io.js` `v1.4`

# es6-shim 0.27.0 (26 Feb 2015)
* Overwrite `Array#slice` so that it supports Array subclasses.
* Improve `Map`/`Set` `TypeError` messages when called as a function. (#321)

# es6-shim 0.26.1 (25 Feb 2015)
* Ensure `Array`/`Array.prototype` functions have the correct name.
* Chrome 40 defines the incorrect name for `Array#values`
* Make sure that `Array.of` works when subclassed.

# es6-shim 0.26.0 (24 Feb 2015)
* Ensure that remaining Object static methods accept primitives.
* Update `chai`
* Document `String.prototype` HTML methods and `Reflect` methods in README

# es6-shim 0.25.3 (22 Feb 2015)
* Removing nonexistent arguments from some String.prototype HTML methods
* All grade A-supported `node`/`iojs` versions now ship with an `npm` that understands `^`.
* Test on `iojs-v1.3`
* Update `chai`
* Add a LICENSE file

# es6-shim 0.25.2 (18 Feb 2015)
* If someone (looking at you, chalk) has previously modified String.prototype with a non-function “bold”, don‘t break. (#315)

# es6-shim 0.25.1 (18 Feb 2015)
* Add Annex B String.prototype HTML methods.
* Overwriting Annex B String.prototype HTML methods in IE 9, which both uppercases the tag names, and fails to escape double quotes.
* Overwriting Annex B String.prototype HTML methods in Safari 4-5, which fails to escape double quotes.
* Ensuring that Date#toString returns “Invalid Date” when the date‘s value is NaN.
* Test on `iojs-v1.2`

# es6-shim 0.25.0 (16 Feb 2015)
* Ensure Object.getOwnPropertyNames accepts primitives.
* Make sure the replaced `Object.keys` is non-enumerable.
* Clean up lots of tests to make failures easier to read, and false negatives less common

# es6-shim 0.24.0 (5 Feb 2015)
* Improving accuracy of Math.expm1 values, and ensuring a shim on Linux FF 35, which reports an inaccurate value for Math.expm1(10).
* Fix bug from 7454db144e5aa251d599415cfb296b67aa3cf992 which prevented String#startsWith and String#endsWith from being overwritten in old Firefox.
* Improve tests across a wider list of browsers
* Ensure that individual Reflect methods are added when possible
* Add Reflect (#313)
* Fix node 0.11: it has an imprecise Math.sinh with very small numbers.
* Alter String#repeat RangeError message to align with Firefox’s native implementation.

# es6-shim 0.23.0 (26 Jan 2015)
* Use Symbol.species when available, else fall back to "@@species" (renamed from "@@create")
* Fix `npm run test-native`
* Correct broken Math implementations: `log1p`, `exmp1`, `tanh`, `acosh`, `cosh`, `sinh`, `round` (#314)
* Update `jscs`, `grunt-saucelabs`, `jshint`

# es6-shim 0.22.2 (4 Jan 2015)
* Faster travis-ci builds
* Better ES3 support: quoting/avoiding reserved words
* Update `mocha`, `jscs`, `jshint`, `grunt-saucelabs`, `uglify-js`

# es6-shim 0.22.1 (13 Dec 2014)
* Make RegExp#flags generic, per spec (#310)

# es6-shim 0.22.0 (12 Dec 2014)
* Add RegExp#flags
* Make `new RegExp` work with both a regex and a flags string
* Remove non-spec `Object.{getPropertyNames,getPropertyDescriptor}`

# es6-shim 0.21.1 (4 Dec 2014)
* Promise/Promise.prototype methods, and String#{startsWith,endsWith} are now not enumerable
* Array#{keys, values, entries} should all be @@unscopeable in browsers that support that
* Ensure that tampering with Function#{call,apply} won’t break internal methods
* Add Math.clz32, RegExp tests
* Update es6-sham UMD
* Update `chai`, `es5-shim`, `grunt-saucelabs`, `jscs`

# es6-shim 0.21.0 (21 Nov 2014)
* String#contains → String#includes per 2014-11-19 TC39 meeting
* Use an invalid identifier as the es6-shim iterator key, so it doesn’t show up in the console as easily.

# es6-shim 0.20.4 (20 Nov 2014)
* Performance improvements: avoid slicing arguments, avoid `Function#call` when possible
* Name `String.{fromCodePoint,raw}` for debugging
* Fix `String.raw` to match spec
* Ensure Chrome’s excess Promise methods are purged
* Ensure `Set#keys === Set#values`, per spec

# es6-shim 0.20.3 (19 Nov 2014)
* Fix Set#add and Map#set to always return "this" (#302)
* Clarify TypeError messages thrown by Map/Set
* Fix Chrome 38 bug with Array#values

# es6-shim 0.20.2 (28 Oct 2014)
* Fix AMD (#299)

# es6-shim 0.20.1 (27 Oct 2014)
* Set#delete and Map#delete should return false unless a deletion occurred. (#298)

# es6-shim 0.20.0 (26 Oct 2014)
* Use a more reliable UMD
* export the global object rather than undefined

# es6-shim 0.19.2 (25 Oct 2014)
* Set#delete and Map#delete should return a boolean indicating success. (#298)
* Make style consistent; add jscs

# es6-shim 0.19.1 (14 Oct 2014)
* Fix Map#set and Set#add to be chainable (#295)
* Update mocha

# es6-shim 0.19.0 (9 Oct 2014)
* Detect and override noncompliant Map in Firefox 32 (#294)
* Fix Map and Set for engines that don’t preserve numeric key order (#292, #290)
* Detect and override noncompliant Safari 7.1 Promises (#289)
* Fix Array#keys and Array#entries in Safari 7.1
* General style and whitespace cleanup
* Update dependencies
* Clean up tests for ES3 by removing reserved words